### PR TITLE
OP-221: Fixed retrieving product definition from OverviewFamily

### DIFF
--- a/IMIS/OverviewFamily.aspx
+++ b/IMIS/OverviewFamily.aspx
@@ -338,7 +338,7 @@ title='<%$ Resources:Resource,L_FAMILY%>'%>
                       <asp:GridView ID="gvPolicies" runat="server"  
                         AutoGenerateColumns="False"
                         EmptyDataText='<%$ Resources:Resource,M_NOPOLICIES %>'
-                        DataKeyNames="PolicyID,ProdID,ExpiryDate"
+                        DataKeyNames="PolicyID,ProdID,ProdUUID, ExpiryDate"
                         CssClass="mGrid"
                         PagerStyle-CssClass="pgr"
                         AlternatingRowStyle-CssClass="alt"
@@ -364,7 +364,7 @@ title='<%$ Resources:Resource,L_FAMILY%>'%>
                     <asp:BoundField DataField="EffectiveDate" HeaderText='<%$ Resources:Resource,L_EFFECTIVEDATE %>'  SortExpression="EffectiveDate" DataFormatString="{0:d}" ></asp:BoundField>
                     <asp:BoundField DataField="StartDate" DataFormatString="{0:d}" HeaderText='<%$ Resources:Resource,L_STARTDATE %>' SortExpression="StartDate" />
                     <asp:BoundField DataField="ExpiryDate" DataFormatString="{0:d}" HeaderText='<%$ Resources:Resource,L_EXPIRYDATE %>' SortExpression="ExpiryDate" />
-                    <asp:HyperLinkField DataNavigateUrlFields = "ProdID"  DataTextField="ProductCode" DataNavigateUrlFormatString = "Product.aspx?p={0}&x=1" HeaderText='<%$ Resources:Resource,L_PRODUCT %>'  HeaderStyle-Width ="80px" >  </asp:HyperLinkField> 
+                    <asp:HyperLinkField DataNavigateUrlFields = "ProdUUID"  DataTextField="ProductCode" DataNavigateUrlFormatString = "Product.aspx?p={0}&x=1" HeaderText='<%$ Resources:Resource,L_PRODUCT %>'  HeaderStyle-Width ="80px" >  </asp:HyperLinkField> 
                     <%--<asp:BoundField DataField="ProductCode"  HeaderText="PRODUCT" SortExpression="ProductCode" />--%>
                     <asp:BoundField DataField="OfficerName"  HeaderText='<%$ Resources:Resource,L_ENROLMENTOFFICERS %>' SortExpression="OfficerName" />                 
                     <asp:BoundField DataField="PolicyStatus" HeaderText='<%$ Resources:Resource,L_POLICYSTATUS %>' SortExpression="PolicyStatus" ></asp:BoundField>

--- a/IMIS_DAL/PolicyDAL.vb
+++ b/IMIS_DAL/PolicyDAL.vb
@@ -89,10 +89,10 @@ Public Class PolicyDAL
         Dim eFamily As New IMIS_EN.tblFamilies
 
 
-        data.setSQLCommand("select pd.InsurancePeriod,FamilyID,EnrollDate,StartDate,ExpiryDate,EffectiveDate,PolicyStatus,isnull(PolicyValue,0) PolicyValue,tblPolicy.ProdID,OfficerID,PolicyStage,isnull(PremiumPaid,0) PremiumPaid," & _
-                           "tblPolicy.isOffline,tblPolicy.ValidityTo from tblPolicy left join (select MAX(policyID) policyID, SUM(Amount) PremiumPaid " & _
-                            "from tblPremium where PolicyID=@PolicyID and ValidityTo is null and isPhotoFee = 0) Premium on Premium.policyID = tblPolicy.PolicyID " & _
-                            " INNER JOIN tblProduct pd ON pd.ProdID = tblPolicy.ProdID" & _
+        data.setSQLCommand("select pd.InsurancePeriod,FamilyID,EnrollDate,StartDate,ExpiryDate,EffectiveDate,PolicyStatus,isnull(PolicyValue,0) PolicyValue,tblPolicy.ProdID,OfficerID,PolicyStage,isnull(PremiumPaid,0) PremiumPaid," &
+                           "tblPolicy.isOffline,tblPolicy.ValidityTo from tblPolicy left join (select MAX(policyID) policyID, SUM(Amount) PremiumPaid " &
+                            "from tblPremium where PolicyID=@PolicyID and ValidityTo is null and isPhotoFee = 0) Premium on Premium.policyID = tblPolicy.PolicyID " &
+                            " INNER JOIN tblProduct pd ON pd.ProdID = tblPolicy.ProdID" &
                             " where tblpolicy.PolicyID = @PolicyID", CommandType.Text)
         data.params("@PolicyID", SqlDbType.Int, ePolicy.PolicyID)
         Dim dr As DataRow = data.Filldata()(0)
@@ -188,7 +188,7 @@ Public Class PolicyDAL
     Public Function GetPolicybyFamily(ByVal FamilyId As Integer, ByVal status As DataTable) As DataTable
 
 
-        data.setSQLCommand("SELECT PolicyId,PolicyUUID,EnrollDate,EffectiveDate,StartDate,ExpiryDate,Status.name As PolicyStatus ,PolicyValue,tblPolicy.isOffline,tblPolicy.ValidityFrom,tblPolicy.ValidityTo,tblPolicy.PolicyStage,ProductCode,LastName + ' ' + OtherNames OfficerName, tblPolicy.ProdID,tblPolicy.FamilyId,F.FamilyUUID " &
+        data.setSQLCommand("SELECT PolicyId,PolicyUUID,EnrollDate,EffectiveDate,StartDate,ExpiryDate,Status.name As PolicyStatus ,PolicyValue,tblPolicy.isOffline,tblPolicy.ValidityFrom,tblPolicy.ValidityTo,tblPolicy.PolicyStage,ProductCode,LastName + ' ' + OtherNames OfficerName, tblPolicy.ProdID,tblPolicy.FamilyId,F.FamilyUUID, tblProduct.ProdUUID " &
                            " FROM tblPolicy INNER JOIN tblProduct ON tblPolicy.ProdID = tblProduct.ProdId" &
                            " INNER JOIN tblFamilies F On F.FamilyID = tblPolicy.FamilyID " &
                            " LEFT OUTER JOIN tblOfficer ON tblPolicy.OfficerId = tblOfficer.OfficerID" &
@@ -206,7 +206,7 @@ Public Class PolicyDAL
     End Function
     Public Function GetProducts() As DataTable
 
-        Dim sSQL As String = "SELECT ProdID,ProductCode FROM tblProduct"
+        Dim sSQL As String = "SELECT ProdID, ProdUUID, ProductCode FROM tblProduct"
         data.setSQLCommand(sSQL, CommandType.Text)
         Return data.Filldata
     End Function


### PR DESCRIPTION
Quick retrieving of product from OverviewFamily was failing due to using product id instead of product uuid.
Ticket: [OP-221](https://openimis.atlassian.net/browse/OP-221)