### PR TITLE
OP-175: PolicyRenewal updates expired policy status

### DIFF
--- a/IMIS_DAL/PolicyRenewalDAL.vb
+++ b/IMIS_DAL/PolicyRenewalDAL.vb
@@ -30,6 +30,7 @@ Public Class PolicyRenewalDAL
 
     Public Sub UpdatePolicyRenewal(RemindingInterval As Integer?, RegionId As Integer?, DistrictId As Integer?, WardId As Integer?, VillageId As Integer?, OfficerId As Integer?, DateFrom As Date?, DateTo As Date?)
         Dim sSQL As String = "uspPolicyRenewalInserts"
+        Dim expSQL As String = "uspPolicyStatusUpdate"
         Dim data As New ExactSQL
 
         data.setSQLCommand(sSQL, CommandType.StoredProcedure)
@@ -45,6 +46,8 @@ Public Class PolicyRenewalDAL
 
         data.ExecuteCommand()
 
+        data.setSQLCommand(expSQL, CommandType.StoredProcedure)
+        data.ExecuteCommand()
     End Sub
 
     Public Function GetPolicyStatus(ByVal RangeFrom As DateTime, ByVal RangeTo As DateTime, ByVal OfficerID As Integer, ByVal RegionId As Integer, ByVal District As Integer, ByVal Village As Integer, ByVal Ward As Integer, ByVal PolicyStatus As Integer) As DataTable


### PR DESCRIPTION
Execution of uspPolicyStatusUpdate procedure was added to PolicyRenewal update.
That allows changing expired policies status from web app, without using Windows Service.
 
TICKET: [OP-175](https://openimis.atlassian.net/jira/software/c/projects/OP/issues/OP-175)
