### PR TITLE
Fixed permission check for claims submssion

### DIFF
--- a/IMIS/FindClaims.aspx.vb
+++ b/IMIS/FindClaims.aspx.vb
@@ -182,7 +182,7 @@ Partial Public Class FindClaims
                 Server.Transfer("Redirect.aspx?perm=0&page=" & IMIS_EN.Enums.Pages.FindClaim.ToString & "&retUrl=" & RefUrl)
             End If
         ElseIf which = 2 Then
-            If Not FindClaimsB.checkRights(IMIS_EN.Enums.Rights.ClaimReview, UserID) Then
+            If Not FindClaimsB.checkRights(IMIS_EN.Enums.Rights.ClaimSubmit, UserID) Then
                 Server.Transfer("Redirect.aspx?perm=0&page=" & IMIS_EN.Enums.Pages.FindClaim.ToString & "&retUrl=" & RefUrl)
             End If
         End If


### PR DESCRIPTION
Permission for claim review (instead of submit) is required to submit a claim, therefore some users can't submit claims even though they have proper permission.