### PR TITLE
OTC-76: The get officers SQL must use admin role

### DIFF
--- a/IMIS/IMIS.vbproj
+++ b/IMIS/IMIS.vbproj
@@ -274,7 +274,8 @@
     </Content>
     <Content Include="Manual\IMIS_manual_fr.pdf" />
     <None Include="My Project\PublishProfiles\IISProfile.pubxml" />
-    <None Include="My Project\PublishProfiles\IMIS.pubxml" />
+    <None Include="My Project\PublishProfiles\IMIS CHF Release.pubxml" />
+    <None Include="My Project\PublishProfiles\IMIS MV Release.pubxml" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/IMIS/My Project/PublishProfiles/IMIS CHF Release.pubxml
+++ b/IMIS/My Project/PublishProfiles/IMIS CHF Release.pubxml
@@ -11,7 +11,7 @@ by editing this MSBuild file. In order to learn more about this please visit htt
     <SiteUrlToLaunchAfterPublish />
     <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>
     <ExcludeApp_Data>False</ExcludeApp_Data>
-    <publishUrl>..\publish</publishUrl>
+    <publishUrl>bin\app.publish.chf\</publishUrl>
     <DeleteExistingFiles>True</DeleteExistingFiles>
     <PrecompileBeforePublish>True</PrecompileBeforePublish>
     <EnableUpdateable>True</EnableUpdateable>

--- a/IMIS/My Project/PublishProfiles/IMIS MV Release.pubxml
+++ b/IMIS/My Project/PublishProfiles/IMIS MV Release.pubxml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DeleteExistingFiles>True</DeleteExistingFiles>
+    <ExcludeApp_Data>False</ExcludeApp_Data>
+    <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <PublishProvider>FileSystem</PublishProvider>
+    <PublishUrl>bin\app.publish.mv\</PublishUrl>
+    <WebPublishMethod>FileSystem</WebPublishMethod>
+    <SiteUrlToLaunchAfterPublish />
+    <PrecompileBeforePublish>True</PrecompileBeforePublish>
+    <EnableUpdateable>True</EnableUpdateable>
+    <DebugSymbols>False</DebugSymbols>
+    <WDPMergeOption>DonotMerge</WDPMergeOption>
+  </PropertyGroup>
+</Project>

--- a/IMIS/User.aspx.vb
+++ b/IMIS/User.aspx.vb
@@ -83,6 +83,9 @@ Partial Public Class User
                 txtPhone.Text = eUsers.Phone
                 txtEmail.Text = eUsers.EmailId
                 txtLoginName.Text = eUsers.LoginName
+                If eUsers.LoginName = "Admin" Then
+                    txtLoginName.Enabled = False
+                End If
                 ' txtPassword.Attributes.Add("value", eUsers.DummyPwd)
                 ' txtConfirmPassword.Attributes.Add("value", eUsers.DummyPwd)
                 If HttpContext.Current.Request.QueryString("r") = 1 Or eUsers.ValidityTo.HasValue Then
@@ -130,6 +133,7 @@ Partial Public Class User
         txtOtherNames.Enabled = enabled
         txtLastName.Enabled = enabled
         txtEmail.Enabled = enabled
+
         txtLoginName.Enabled = enabled
         ddlHFNAME.Enabled = enabled
         pnlRole.Enabled = enabled

--- a/IMIS_DAL/ClaimAdminDAL.vb
+++ b/IMIS_DAL/ClaimAdminDAL.vb
@@ -60,10 +60,11 @@ Public Class ClaimAdminDAL
 
     'Corrected
     Public Function GetClaimAdmins(ByVal eClaimAdmin As IMIS_EN.tblClaimAdmin, ByVal All As Boolean) As DataTable
-        Query = "select ClaimAdminId,ClaimAdminUUID,ClaimAdminCode,ClaimAdminCode +' - '+ ca.LastName Description,ca.LastName,ca.OtherNames,ca.DOB,ca.Phone,ca.ValidityFrom" &
+        Query = "DECLARE @AdminUser INT;SELECT @AdminUser = UserID FROM tblUsers WHERE LoginName = 'Admin' AND ValidityTo IS NULL; " &
+           "select DISTINCT ClaimAdminId,ClaimAdminUUID,ClaimAdminCode,ClaimAdminCode +' - '+ ca.LastName Description,ca.LastName,ca.OtherNames,ca.DOB,ca.Phone,ca.ValidityFrom" &
            ",ca.ValidityTo,ca.LegacyId,ca.AuditUserId,tblHF.HfID,tblHF.HFCode, ca.EmailId,ISNULL(ca.HasLogin,0) HasLogin from tblClaimAdmin ca" &
            " inner join tblHF on ca.HFId = tblHF.HfID" &
-           " inner join tblUsersDistricts ud on tblHF.LocationId = ud.LocationId And ud.UserID = @UserID" &
+           " inner join tblUsersDistricts ud on tblHF.LocationId = ud.LocationId And (ud.UserID = @UserID OR @UserID = @AdminUser)" &
            " WHERE ca.ClaimAdminCode like @Code AND " &
            " LastName LIKE @LastName AND OtherNames LIKE @OtherNames  AND ISNULL(ca.Phone,'') LIKE @Phone" &
            " AND ISNULL(ca.EmailId,'') LIKE @EmailId"

--- a/IMIS_DAL/HealthFacilityDAL.vb
+++ b/IMIS_DAL/HealthFacilityDAL.vb
@@ -277,14 +277,15 @@ Public Class HealthFacilityDAL
     Public Function GetHFCodes(ByVal UserId As Integer, ByVal LocationId As Integer, Optional ByRef Hfid As Integer = 0) As DataTable
         Dim data As New ExactSQL
         Dim sSQL As String = ""
-        sSQL = "SELECT @hfid = isnull(hfid,0)"
+        sSQL += " DECLARE @AdminUser INT;SELECT @AdminUser = UserID FROM tblUsers WHERE LoginName = 'Admin' AND ValidityTo IS NULL"
+        sSQL += " SELECT @hfid = isnull(hfid,0)"
         sSQL += " FROM tblUsers"
         sSQL += " WHERE UserID = @userid;"
-        sSQL += " SELECT tblhf.HfID,tblhf.HfUUID,HFCode + ' - ' + HFNAME HFCODE"
+        sSQL += " SELECT DISTINCT tblhf.HfID,tblhf.HfUUID,HFCode + ' - ' + HFNAME HFCODE"
         sSQL += " FROM tblusersdistricts"
         sSQL += " INNER JOIN tblHF on tblhf.LocationId = tblusersdistricts.LocationId and tblHF.validityto IS NULL"
         sSQL += " INNER JOIN tblLocations l on l.LocationID = tblusersdistricts.LocationId"
-        sSQL += " WHERE tblusersdistricts.userid = @UserId"
+        sSQL += " WHERE (tblusersdistricts.userid = @UserId OR @UserId = @AdminUser)"
         sSQL += " AND (@hfid = 0 or @hfid= tblhf.hfid ) and (@LocationId = l.LocationID or @LocationId = l.ParentLocationID OR @LocationId  = 0 )"
         sSQL += " AND tblusersdistricts.validityto is null"
         sSQL += " ORDER BY hfCode;"
@@ -377,10 +378,11 @@ Public Class HealthFacilityDAL
     Public Function getHFUserLocation(ByVal UserId As Integer, ByVal Hfid As Integer) As DataTable
         Dim data As New ExactSQL
         Dim sSQL As String = ""
-        sSQL = "SELECT  D.DistrictId, UD.UserDistrictID,UD.LocationId FROM tblHF HF "
+        sSQL += "DECLARE @AdminUser INT;SELECT @AdminUser = UserID FROM tblUsers WHERE LoginName = 'Admin' AND ValidityTo IS NULL; "
+        sSQL += "SELECT  D.DistrictId, UD.UserDistrictID,UD.LocationId FROM tblHF HF "
         sSQL += " INNER JOIN tblUsersDistricts UD ON UD.LocationId = HF.LocationId "
         sSQL += " AND UD.ValidityTo IS NULL"
-        sSQL += " AND UD.UserID = @UserID"
+        sSQL += " AND (UD.UserID = @UserId OR @UserId = @AdminUser)"
         sSQL += " INNER JOIN tblDistricts D ON D.DistrictId = UD.LocationId"
         sSQL += " INNER JOIN tblRegions R ON R.RegionId = D.Region"
         sSQL += " WHERE HF.ValidityTo IS NULL"

--- a/IMIS_DAL/LocationsDAL.vb
+++ b/IMIS_DAL/LocationsDAL.vb
@@ -31,12 +31,13 @@ Public Class LocationsDAL
     Public Function GetDistricts(ByVal UserID As Integer, Optional RegionId As Integer = 0) As DataTable
         Dim data As New ExactSQL
         Dim sSQL As String = ""
-        sSQL = "Select distinct tbldistricts.DistrictID,DistrictName,DistrictCode, Region"
+        sSQL += " DECLARE @AdminUser INT;SELECT @AdminUser = UserID FROM tblUsers WHERE LoginName = 'Admin' AND ValidityTo IS NULL"
+        sSQL += " Select distinct tbldistricts.DistrictID,DistrictName,DistrictCode, Region"
         sSQL += " from tblDistricts"
         sSQL += " left outer join tblUsersDistricts on tbldistricts.districtID = [tblUsersDistricts].[LocationID]"
         sSQL += " and tblUsersDistricts.validityto is null"
         sSQL += " inner join tblRegions on tblDistricts.Region = tblRegions.RegionId"
-        sSQL += " where case when @userid = 0 then 0 else userid end =  @UserID"
+        sSQL += " where ((case when @userid = 0 then 0 else userid end =  @UserID) OR (@AdminUser = @UserID))"
         sSQL += " and case when @RegionId = 0 then 0 else RegionId end = @RegionId"
         sSQL += " and  tblDistricts.ValidityTo is NULL"
         sSQL += " and tblRegions.ValidityTo is null"
@@ -433,12 +434,13 @@ Public Class LocationsDAL
     'Corrected This return
     Public Function GetRegions(UserId As Integer) As DataTable
         Dim sSQL As String = ""
-        sSQL = ";WITH Regions AS"
+        sSQL += " DECLARE @AdminUser INT;SELECT @AdminUser = UserID FROM tblUsers WHERE LoginName = 'Admin' AND ValidityTo IS NULL"
+        sSQL += " ;WITH Regions AS"
         sSQL += " ("
         sSQL += " SELECT ROW_NUMBER() OVER(PARTITION BY R.RegionId ORDER BY UD.UserId DESC)RNo,IIF(UD.UserID IS NULL, 0, 1)Checked, R.RegionId, R.RegionName,RegionCode, R.ValidityFrom, R.ValidityTo, R.LegacyId, R.AuditUserId"
         sSQL += " FROM tblRegions R"
         sSQL += " INNER JOIN tblDistricts D ON R.RegionId = D.Region AND D.ValidityTo IS NULL"
-        sSQL += " INNER JOIN tblUsersDistricts UD ON D.DistrictID = UD.LocationId AND UD.UserId = @UserId AND UD.ValidityTo IS NULL"
+        sSQL += " INNER JOIN tblUsersDistricts UD ON D.DistrictID = UD.LocationId AND (UD.UserId = @UserId OR @UserId = @AdminUser) AND UD.ValidityTo IS NULL"
         sSQL += " WHERE R.ValidityTo IS NULL"
         sSQL += " GROUP BY UD.UserID, R.RegionId, R.RegionName, R.ValidityFrom, R.ValidityTo, R.LegacyId, R.AuditUserId,RegionCode"
         sSQL += " )"

--- a/IMIS_DAL/OfficersDAL.vb
+++ b/IMIS_DAL/OfficersDAL.vb
@@ -175,14 +175,14 @@ Public Class OfficersDAL
         Dim sSQL As String = ""
 
         'sSQL = "select tblOfficer.*,Districtname from tblOfficer left outer join tblDistricts on tblOfficer.LocationId = tblDistricts.DistrictID inner join tblUsersDistricts UD on UD.LocationId = tblOfficer.LocationId and UD.userid = @userid and UD.ValidityTo is null WHERE code like @Code AND  LastName LIKE @LastName AND OtherNames LIKE @OtherNames  AND Phone  like @Phone AND ISNULL(EmailId, '') LIKE @EmailId"
-
-        sSQL = " SELECT DISTINCT O.OfficerID,O.OfficerUUID,O.Code,O.OtherNames,O.LastName,O.Phone,O.DOB,O.ValidityFrom, O.ValidityTo,"
+        sSQL += " DECLARE @AdminUser INT;SELECT @AdminUser = UserID FROM tblUsers WHERE LoginName = 'Admin' AND ValidityTo IS NULL"
+        sSQL += " SELECT DISTINCT O.OfficerID,O.OfficerUUID,O.Code,O.OtherNames,O.LastName,O.Phone,O.DOB,O.ValidityFrom, O.ValidityTo,"
         sSQL += " L.RegionName , L.DistrictName, ISNULL(HasLogin,0) HasLogin"
         sSQL += " FROM tblOfficer O"
         sSQL += " INNER JOIN uvwLocations L ON ISNULL(L.LocationId, 0) = ISNULL(O.LocationId, 0) "
         sSQL += " INNER JOIN (SELECT UD.UserId, L.DistrictId, L.RegionId FROM tblUsersDistricts UD"
         sSQL += " INNER JOIN uvwLocations L ON L.DistrictId = UD.LocationId"
-        sSQL += " WHERE UD.ValidityTo IS NULL AND (UD.UserId = @UserId OR @UserId = 0)"
+        sSQL += " WHERE UD.ValidityTo IS NULL AND (UD.UserId = @UserId OR @UserId = 0 OR @UserId = @AdminUser)"
         sSQL += " GROUP BY UD.UserId, L.DistrictId, L.RegionId )UD ON UD.DistrictId = O.LocationId"
         sSQL += " INNER JOIN tblUsers U ON U.UserId = UD.UserId"
 

--- a/IMIS_DAL/PayersDAL.vb
+++ b/IMIS_DAL/PayersDAL.vb
@@ -80,7 +80,7 @@ Public Class PayersDAL
     Public Function GetPayers(ByVal ePayer As IMIS_EN.tblPayer, ByVal dtPayerType As DataTable, ByVal All As Boolean) As DataTable
         Dim data As New ExactSQL
         Dim sSql As String = ""
-
+        sSql += " DECLARE @AdminUser INT;SELECT @AdminUser = UserID FROM tblUsers WHERE LoginName = 'Admin' AND ValidityTo IS NULL"
         sSql += " SELECT P.PayerId, P.PayerUUID, P.PayerUUID, P.PayerName, P.PayerAddress, P.Phone, P.ValidityFrom, P.ValidityTo,"
         sSql += " L.RegionName , L.DistrictName,"
         sSql += " P.PayerType, PayerType.AltLanguage, L.RegionId, L.DistrictId"
@@ -89,7 +89,7 @@ Public Class PayersDAL
         sSql += " INNER JOIN uvwLocations L ON ISNULL(L.LocationId, 0) = ISNULL(P.LocationId, 0)"
 
         sSql += " INNER JOIN ( SELECT L.DistrictId, L.RegionId FROM tblUsersDistricts UD"
-        sSql += " INNER JOIN uvwLocations L ON L.DistrictId = UD.LocationId WHERE UD.ValidityTo IS NULL AND (UD.UserId = @UserId OR @UserId = 0)"
+        sSql += " INNER JOIN uvwLocations L ON L.DistrictId = UD.LocationId WHERE UD.ValidityTo IS NULL AND (UD.UserId = @UserId OR @UserId = 0 OR @UserId = @AdminUser)"
         sSql += " GROUP BY L.DistrictId, L.RegionId )UD ON UD.DistrictId = P.LocationId  OR UD.RegionId = P.LocationId OR P.LocationId IS NULL"
 
 

--- a/IMIS_DAL/UsersDAL.vb
+++ b/IMIS_DAL/UsersDAL.vb
@@ -135,7 +135,7 @@ Public Class UsersDAL
         sSQL += "  Where U.UserID In"
         sSQL += " (SELECT DISTINCT UD.Userid FROM tblUsersDistricts AD"
         sSQL += "  INNER Join tblUsersDistricts UD ON UD.LocationId = AD.LocationId And AD.ValidityTo Is NULL And UD.ValidityTo Is NULL"
-        sSQL += "  WHERE AD.UserID =@AuthorityID AND (AD.LocationID = @DistrictID Or @DistrictID =0)"
+        sSQL += "  WHERE (AD.UserID =@AuthorityID OR @AuthorityID = @AdminUser) AND (AD.LocationID = @DistrictID Or @DistrictID =0)"
         'Below was a self join of tblLocation on LocationID, changed by Salumu on the 7th Aug 2019, joined with tblRegion
         If eUser.tblLocations.RegionId > 0 And eUser.tblLocations.DistrictId = 0 Then
             sSQL += " AND  UD.LocationId IN (SELECT DI.LocationID FROM tblLocations DI


### PR DESCRIPTION
Changes:
- Made Admin account name unchangable
- Added checks for Admin acoount in several search queries

Unrelated changes:
- Added publish configuration for MV Release and CHF Release web apps.