### PR TITLE
OTC-183: fix dismissing insurance product

### DIFF
--- a/IMIS/Policy.aspx.vb
+++ b/IMIS/Policy.aspx.vb
@@ -193,6 +193,7 @@ Partial Public Class Policy
 
                 'Policy is in Renewal Mode
             ElseIf Not ePolicy.PolicyID = 0 And hfPolicyStage.Value = "R" Then
+
                 Policy.LoadPolicy(ePolicy, 0)
                 txtEnrollmentDate.Text = Format(Date.Today, "dd/MM/yyyy")
                 'ddlProduct.SelectedValue = ePolicy.tblProduct.ProdID
@@ -201,6 +202,7 @@ Partial Public Class Policy
                 getPolicyValue(sender, e)
 
             ElseIf ePolicy.PolicyID = 0 And hfPolicyStage.Value = "R" Then 'Ruzo : Added on 11 Oct, to fix loading of product when renewing.  
+
                 txtEnrollmentDate.Text = Format(Date.Today, "dd/MM/yyyy")
                 'ddlProduct.SelectedValue = ePolicy.tblProduct.ProdID
                 SetProductForRenewal()
@@ -249,6 +251,7 @@ Partial Public Class Policy
         If IsDate(txtEnrollmentDate.Text) Then
 
             Dim dEnrolDate As Date = Date.ParseExact(txtEnrollmentDate.Text, "dd/MM/yyyy", Nothing)
+
             'OTC-183: Renewing of a policy on a previous date is not possible'
             'eProduct was = 0 before that change and that is why the insurance product'
             'in the field was dismissed'
@@ -584,8 +587,11 @@ Partial Public Class Policy
         Else
             EnrollDate = Date.ParseExact(txtEnrollmentDate.Text, "dd/MM/yyyy", Nothing)
         End If
+
         eProd = Policy.GetProductForRenewal(CInt(eProduct.ProdID), EnrollDate)
+
         ddlProduct.SelectedValue = eProd.ProdID
+
         If ddlProduct.SelectedValue = 0 Then
             ddlProduct.Items.Add(New ListItem(eProd.ProductCode, eProd.ProdID))
             ddlProduct.SelectedValue = eProd.ProdID


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OTC-183

In that PR I want to merge fix for the issue described in above ticket. Now is possible to change "enrolment date" - the product is not dismissing from field. 
![otc-183](https://user-images.githubusercontent.com/52816247/113320073-65b53180-9312-11eb-84cd-bf0083314ebb.PNG)
