### PR TITLE
OTC-160: fixed bug with restore after saving new claim

### DIFF
--- a/IMIS/Claim.aspx.vb
+++ b/IMIS/Claim.aspx.vb
@@ -946,7 +946,17 @@ Partial Public Class Claim
     End Sub
     Protected Sub btnRestore_Click(sender As Object, e As EventArgs) Handles btnRestore.Click
         Try
-            Dim hfClaimUUID As Guid = Guid.Parse(HttpContext.Current.Request.QueryString("c"))
+            'OTC-160: Restoring claim doesn't work just after saving a new claim'
+            'here was error because the URL structure was different after staying'
+            'in page after saving claim. Therefore we had an error in that case'
+            Dim hfClaimUUID As Guid
+            If HttpContext.Current.Request.QueryString("c") IsNot Nothing Then
+                hfClaimUUID = Guid.Parse(HttpContext.Current.Request.QueryString("c"))
+            Else
+                'No claim uuid in URL. Take the claims by code from text field'
+                Dim ClaimCode As String = txtCLAIMCODEData.Text
+                hfClaimUUID = claim.GetClaimUUIDByClaimCode(ClaimCode)
+            End If
             hfClaimID.Value = If(hfClaimUUID.Equals(Guid.Empty), 0, claimBI.GetClaimIdByUUID(hfClaimUUID))
 
             eClaim.ClaimID = hfClaimID.Value

--- a/IMIS/Claim.aspx.vb
+++ b/IMIS/Claim.aspx.vb
@@ -946,9 +946,6 @@ Partial Public Class Claim
     End Sub
     Protected Sub btnRestore_Click(sender As Object, e As EventArgs) Handles btnRestore.Click
         Try
-            'OTC-160: Restoring claim doesn't work just after saving a new claim'
-            'here was error because the URL structure was different after staying'
-            'in page after saving claim. Therefore we had an error in that case'
             Dim hfClaimUUID As Guid
             If HttpContext.Current.Request.QueryString("c") IsNot Nothing Then
                 hfClaimUUID = Guid.Parse(HttpContext.Current.Request.QueryString("c"))

--- a/IMIS_BI/ClaimBI.vb
+++ b/IMIS_BI/ClaimBI.vb
@@ -121,4 +121,9 @@ Public Class ClaimBI
         Dim Claim As New IMIS_BL.ClaimsBL
         Return Claim.GetClaimUUIDByID(id)
     End Function
+    Public Function GetClaimUUIDByClaimCode(ByVal ClaimCode As String) As Guid
+        'OTC-160: Restoring claim doesn't work just after saving a new claim'
+        Dim Claim As New IMIS_BL.ClaimsBL
+        Return Claim.GetClaimUUIDByClaimCode(ClaimCode)
+    End Function
 End Class

--- a/IMIS_BI/ClaimBI.vb
+++ b/IMIS_BI/ClaimBI.vb
@@ -122,7 +122,6 @@ Public Class ClaimBI
         Return Claim.GetClaimUUIDByID(id)
     End Function
     Public Function GetClaimUUIDByClaimCode(ByVal ClaimCode As String) As Guid
-        'OTC-160: Restoring claim doesn't work just after saving a new claim'
         Dim Claim As New IMIS_BL.ClaimsBL
         Return Claim.GetClaimUUIDByClaimCode(ClaimCode)
     End Function

--- a/IMIS_BL/ClaimsBL.vb
+++ b/IMIS_BL/ClaimsBL.vb
@@ -528,4 +528,9 @@ Public Class ClaimsBL
         Dim Claim As New IMIS_DAL.ClaimsDAL
         Return Claim.GetClaimUUIDByID(id).Rows(0).Item(0)
     End Function
+    Public Function GetClaimUUIDByClaimCode(ByVal ClaimCode As String) As Guid
+        'OTC-160: Restoring claim doesn't work just after saving a new claim'
+        Dim Claim As New IMIS_DAL.ClaimsDAL
+        Return Claim.GetClaimUUIDByClaimCode(ClaimCode).Rows(0).Item(0)
+    End Function
 End Class

--- a/IMIS_BL/ClaimsBL.vb
+++ b/IMIS_BL/ClaimsBL.vb
@@ -530,6 +530,11 @@ Public Class ClaimsBL
     End Function
     Public Function GetClaimUUIDByClaimCode(ByVal ClaimCode As String) As Guid
         Dim Claim As New IMIS_DAL.ClaimsDAL
-        Return Claim.GetClaimUUIDByClaimCode(ClaimCode).Rows(0).Item(0)
+        Dim Result As DataTable = Claim.GetClaimUUIDByClaimCode(ClaimCode)
+        If Result IsNot Nothing And Result.Rows.Count > 0 Then
+            Return Result.Rows(0).Item(0)
+        Else
+            Return Guid.Empty
+        End If
     End Function
 End Class

--- a/IMIS_BL/ClaimsBL.vb
+++ b/IMIS_BL/ClaimsBL.vb
@@ -529,7 +529,6 @@ Public Class ClaimsBL
         Return Claim.GetClaimUUIDByID(id).Rows(0).Item(0)
     End Function
     Public Function GetClaimUUIDByClaimCode(ByVal ClaimCode As String) As Guid
-        'OTC-160: Restoring claim doesn't work just after saving a new claim'
         Dim Claim As New IMIS_DAL.ClaimsDAL
         Return Claim.GetClaimUUIDByClaimCode(ClaimCode).Rows(0).Item(0)
     End Function

--- a/IMIS_DAL/ClaimsDAL.vb
+++ b/IMIS_DAL/ClaimsDAL.vb
@@ -1046,4 +1046,16 @@ Public Class ClaimsDAL
 
         Return data.Filldata
     End Function
+    Public Function GetClaimUUIDByClaimCode(ByVal ClaimCode As String) As DataTable
+        'OTC-160: Restoring claim doesn't work just after saving a new claim'
+        Dim sSQL As String = ""
+        Dim data As New ExactSQL
+
+        sSQL = "select ClaimUUID from tblClaim where ClaimCode = @ClaimCode and ValidityTo is NULL"
+
+        data.setSQLCommand(sSQL, CommandType.Text)
+        data.params("@ClaimCode", SqlDbType.NVarChar, 8, ClaimCode)
+
+        Return data.Filldata
+    End Function
 End Class

--- a/IMIS_DAL/ClaimsDAL.vb
+++ b/IMIS_DAL/ClaimsDAL.vb
@@ -1047,7 +1047,6 @@ Public Class ClaimsDAL
         Return data.Filldata
     End Function
     Public Function GetClaimUUIDByClaimCode(ByVal ClaimCode As String) As DataTable
-        'OTC-160: Restoring claim doesn't work just after saving a new claim'
         Dim sSQL As String = ""
         Dim data As New ExactSQL
 


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OTC-160

In that PR I want to fix bug described in that ticket. Now after my fixes there is no error when user want to restore claim after saving new claim. The error was due to different URL structure after saving new claim (comparing to page when we enter to claim details)

![pr_OTC-160](https://user-images.githubusercontent.com/52816247/113413501-255dbe00-93bb-11eb-86c2-7fa9d3666b9f.PNG)
