### PR TITLE
OP-304: Funding region should not be displayed

### DIFF
--- a/IMIS_DAL/LocationsDAL.vb
+++ b/IMIS_DAL/LocationsDAL.vb
@@ -42,7 +42,6 @@ Public Class LocationsDAL
         sSQL += " and  tblDistricts.ValidityTo is NULL"
         sSQL += " and tblRegions.ValidityTo is null"
         sSQL += " order by DistrictName"
-
         data.setSQLCommand(sSQL, CommandType.Text)
         data.params("@UserID", SqlDbType.Int, UserID)
         data.params("@RegionId", SqlDbType.Int, RegionId)
@@ -446,7 +445,7 @@ Public Class LocationsDAL
         sSQL += " )"
         sSQL += " SELECT Checked, RegionId, RegionName,RegionCode, ValidityFrom, ValidityTo, LegacyId, AuditUserId"
         sSQL += " FROM Regions"
-        sSQL += " WHERE RNo = 1"
+        sSQL += " WHERE RNo = 1 AND RegionName <> 'Funding'"
 
         Dim data As New ExactSQL
         data.setSQLCommand(sSQL, CommandType.Text)
@@ -479,7 +478,7 @@ Public Class LocationsDAL
         sSQL += "   Group BY UD.UserID, R.RegionId, R.RegionName, R.ValidityFrom, R.ValidityTo, R.LegacyId, R.AuditUserId,RegionCode ) "
         sSQL += " SELECT Checked, RegionId, RegionName,RegionCode, ValidityFrom, ValidityTo, LegacyId, AuditUserId FROM Regions "
 
-        sSQL += " WHERE RNo = 1"
+        sSQL += " WHERE RNo = 1 AND RegionName <> 'Funding'"
 
 
         Dim data As New ExactSQL
@@ -499,7 +498,7 @@ Public Class LocationsDAL
         sSQL += " INNER JOIN tblDistricts D ON R.RegionId=D.Region"
         sSQL += " INNER JOIN tblUsersDistricts UD ON UD.LocationId = D.DistrictID"
         sSQL += " INNER JOIN tblUsers U ON U.UserID = UD.UserID"
-        sSQL += " WHERE R.ValidityTo IS NULL AND D.ValidityTo IS NULL AND UD.ValidityTo IS NULL AND UD.UserID= @UserId"
+        sSQL += " WHERE R.ValidityTo IS NULL AND D.ValidityTo IS NULL AND UD.ValidityTo IS NULL AND UD.UserID= @UserId AND R.RegionName <> 'Funding'"
         sSQL += " GROUP BY RegionName"
 
 


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OP-304
I think problem was related to the some inline SQLs in "LocationDAL.vb". Some "SELECTs" doesn't contain a condition to not fetch RegionName called "Funding".

This problem will be solved after my changes in such pages as:
- User
- Location
- Product
- Family
- Insuree
- MainPage (where we have list of regions available for current logged user) 

![op-304](https://user-images.githubusercontent.com/52816247/114716888-cc841300-9d34-11eb-84fc-b313fe1ce060.PNG)
![op-304_2](https://user-images.githubusercontent.com/52816247/114716901-ce4dd680-9d34-11eb-8bb7-c19c75d5b375.PNG)
![op-304_3](https://user-images.githubusercontent.com/52816247/114717051-f4737680-9d34-11eb-84f7-44650d9a559e.PNG)
![op-304_4](https://user-images.githubusercontent.com/52816247/114717060-f5a4a380-9d34-11eb-92e5-6a9ff0e3d226.PNG)

