### PR TITLE
OTC-248: USERS CANT ADD SERVICE CODE UNDER CLAIM - HEALTH FACILITY CLAIMS

### DIFF
--- a/IMIS/Claim.aspx.vb
+++ b/IMIS/Claim.aspx.vb
@@ -397,22 +397,8 @@ Partial Public Class Claim
             'hfClaimAdminId.Value = 0
             'txtClaimAdminCode.Text = String.Empty
 
-            Dim dtS As DataTable = CType(Session("vsServices"), DataTable)
-            Dim dtI As DataTable = CType(Session("vsItems"), DataTable)
-            Dim counter As Integer
+            ServiceItemGridBinding()
 
-            dtS.Clear()
-            dtI.Clear()
-            For counter = 1 To IMIS_EN.AppConfiguration.DefaultClaimRows
-                dtS.Rows.Add(dtS.NewRow())
-                dtI.Rows.Add(dtI.NewRow())
-            Next
-
-            gvService.DataSource = dtS
-            gvService.DataBind()
-
-            gvItems.DataSource = dtI
-            gvItems.DataBind()
             txtCHFIDData.Focus()
         Catch ex As Exception
             'lblMsg.Text = imisgen.getMessage("M_ERRORMESSAGE")


### PR DESCRIPTION
Changes:
- Changed B_ADD_Click not to reference current session to generate cleared rows, instead resused the ServiceItemGridBinding call.

[https://openimis.atlassian.net/browse/OTC-248](
https://openimis.atlassian.net/browse/OTC-248)