### PR TITLE
OTC-68: RFC 115 Supressing of automatic filling of locations

### DIFF
--- a/IMIS/ChangeFamily.aspx.vb
+++ b/IMIS/ChangeFamily.aspx.vb
@@ -97,8 +97,8 @@ Partial Public Class ChangeFamily
             hfFamilyIDValue.Value = eFamily.FamilyID
             ChangeFamily.GetFamilyHeadInfo(eFamily)
             hfInsureeIDValue.Value = eFamily.tblInsuree.InsureeID
-        
-            Dim dtRegions As DataTable = ChangeFamily.GetRegions(imisgen.getUserId(Session("User")), True)
+
+            Dim dtRegions As DataTable = ChangeFamily.GetRegions(imisgen.getUserId(Session("User")), False)
             ddlRegion.DataSource = dtRegions
             ddlRegion.DataValueField = "RegionId"
             ddlRegion.DataTextField = "RegionName"
@@ -181,7 +181,7 @@ Partial Public Class ChangeFamily
         End Try
     End Sub
     Private Sub FillDistrict()
-        Dim dtDistricts As DataTable = ChangeFamily.GetDistricts(imisgen.getUserId(Session("User")), True, ddlRegion.SelectedValue)
+        Dim dtDistricts As DataTable = ChangeFamily.GetDistricts(imisgen.getUserId(Session("User")), False, ddlRegion.SelectedValue)
         ddlDistrict.DataSource = dtDistricts
         ddlDistrict.DataValueField = "DistrictId"
         ddlDistrict.DataTextField = "DistrictName"
@@ -211,7 +211,7 @@ Partial Public Class ChangeFamily
         getVillages()
     End Sub
     Private Sub GetWards()
-        Dim dtWards As DataTable = ChangeFamily.GetWards(ddlDistrict.SelectedValue, True)
+        Dim dtWards As DataTable = ChangeFamily.GetWards(ddlDistrict.SelectedValue, False)
         Dim wards As Integer = dtWards.Rows.Count
         If wards > 0 Then
             ddlWard.DataSource = dtWards
@@ -235,7 +235,7 @@ Partial Public Class ChangeFamily
         End If
 
         If Wards > 0 Then
-            ddlVillage.DataSource = ChangeFamily.GetVillages(ddlWard.SelectedValue, True)
+            ddlVillage.DataSource = ChangeFamily.GetVillages(ddlWard.SelectedValue, False)
             ddlVillage.DataValueField = "VillageId"
             ddlVillage.DataTextField = "VillageName"
             ddlVillage.DataBind()

--- a/IMIS/Family.aspx.vb
+++ b/IMIS/Family.aspx.vb
@@ -154,7 +154,7 @@ Public Class Family
 
         RunPageSecurity()
         Try
-            Dim dtRegions As DataTable = Family.GetRegions(imisgen.getUserId(Session("User")), True)
+            Dim dtRegions As DataTable = Family.GetRegions(imisgen.getUserId(Session("User")), False)
             ddlRegion.DataSource = dtRegions
             ddlRegion.DataValueField = "RegionId"
             ddlRegion.DataTextField = "RegionName"
@@ -314,13 +314,13 @@ Public Class Family
 
 
     Private Sub FillFSPDistricts()
-        ddlFSPDistrict.DataSource = Family.GetDistrictsAll(imisgen.getUserId(Session("User")), ddlFSPRegion.SelectedValue, True)
+        ddlFSPDistrict.DataSource = Family.GetDistrictsAll(imisgen.getUserId(Session("User")), ddlFSPRegion.SelectedValue, False)
         ddlFSPDistrict.DataValueField = "DistrictId"
         ddlFSPDistrict.DataTextField = "DistrictName"
         ddlFSPDistrict.DataBind()
     End Sub
     Private Sub FillDistricts()
-        Dim dtDistricts As DataTable = Family.GetDistricts(imisgen.getUserId(Session("User")), True, ddlRegion.SelectedValue)
+        Dim dtDistricts As DataTable = Family.GetDistricts(imisgen.getUserId(Session("User")), False, ddlRegion.SelectedValue)
         ddlDistrict.DataSource = dtDistricts
         ddlDistrict.DataValueField = "DistrictId"
         ddlDistrict.DataTextField = "DistrictName"
@@ -353,7 +353,7 @@ Public Class Family
         End Try
     End Sub
     Private Sub GetWards()
-        Dim dtWards As DataTable = Family.GetWards(ddlDistrict.SelectedValue, True)
+        Dim dtWards As DataTable = Family.GetWards(ddlDistrict.SelectedValue, False)
         Dim wards As Integer = dtWards.Rows.Count
         If wards > 0 Then
             ddlWard.DataSource = dtWards
@@ -380,7 +380,7 @@ Public Class Family
     Private Sub getVillages(Optional ByVal Wards As Integer = 1)
         If ddlWard.SelectedIndex < 0 Then Exit Sub
         If Wards > 0 And Not ddlWard.SelectedValue = 0 Then
-            ddlVillage.DataSource = Family.GetVillages(ddlWard.SelectedValue, True)
+            ddlVillage.DataSource = Family.GetVillages(ddlWard.SelectedValue, False)
             ddlVillage.DataValueField = "VillageId"
             ddlVillage.DataTextField = "VillageName"
             ddlVillage.DataBind()
@@ -668,7 +668,7 @@ Public Class Family
         FillCurrentDistricts()
     End Sub
     Private Sub FillCurrentDistricts()
-        Dim dtCurDistrict As DataTable = Family.GetDistrictsAll(imisgen.getUserId(Session("User")), Val(ddlCurrentRegion.SelectedValue), True)
+        Dim dtCurDistrict As DataTable = Family.GetDistrictsAll(imisgen.getUserId(Session("User")), Val(ddlCurrentRegion.SelectedValue), False)
         ddlCurDistrict.DataSource = dtCurDistrict
         ddlCurDistrict.DataValueField = "DistrictId"
         ddlCurDistrict.DataTextField = "DistrictName"

--- a/IMIS_BI/ChangeFamilyBI.vb
+++ b/IMIS_BI/ChangeFamilyBI.vb
@@ -52,15 +52,15 @@ Public Class ChangeFamilyBI
     End Sub
     Public Function GetDistricts(ByVal userId As Integer, Optional ByVal showSelect As Boolean = False, Optional ByVal RegionId As Integer = 0) As DataTable
         Dim Districts As New IMIS_BL.LocationsBL
-        Return Districts.GetDistricts(userId, True, RegionId)
+        Return Districts.GetDistricts(userId, showSelect, RegionId)
     End Function
     Public Function GetWards(ByVal DistrictID As Integer, Optional ByVal showSelect As Boolean = False) As DataTable
         Dim Wards As New IMIS_BL.LocationsBL
-        Return Wards.GetWards(DistrictID, True)
+        Return Wards.GetWards(DistrictID, showSelect)
     End Function
     Public Function GetVillages(ByVal WardId As Integer, Optional ByVal showSelect As Boolean = False) As DataTable
         Dim Villages As New IMIS_BL.LocationsBL
-        Return Villages.GetVillages(WardId, True)
+        Return Villages.GetVillages(WardId, showSelect)
     End Function
     Public Sub LoadFamily(ByRef eFamily As IMIS_EN.tblFamilies)
         Dim Family As New IMIS_BL.FamilyBL

--- a/IMIS_BI/FamilyBI.vb
+++ b/IMIS_BI/FamilyBI.vb
@@ -37,19 +37,19 @@ Public Class FamilyBI
     End Sub
     Public Function GetDistricts(ByVal userId As Integer, Optional ByVal showSelect As Boolean = False, Optional ByVal RegionId As Integer = 0) As DataTable
         Dim Districts As New IMIS_BL.LocationsBL
-        Return Districts.GetDistricts(userId, True, RegionId)
+        Return Districts.GetDistricts(userId, showSelect, RegionId)
     End Function
     Public Function GetDistrictsAll(ByVal userID As Integer, Optional RegionId As Integer = 0, Optional ByVal showSelect As Boolean = False) As DataTable
         Dim Districts As New IMIS_BL.LocationsBL
-        Return Districts.GetDistrictsAll(userID, RegionId, True)
+        Return Districts.GetDistrictsAll(userID, RegionId, showSelect)
     End Function
     Public Function GetWards(ByVal DistrictID As Integer, Optional ByVal showSelect As Boolean = False) As DataTable
         Dim Wards As New IMIS_BL.LocationsBL
-        Return Wards.GetWards(DistrictID, True)
+        Return Wards.GetWards(DistrictID, showSelect)
     End Function
     Public Function GetVillages(ByVal WardId As Integer, Optional ByVal showSelect As Boolean = False) As DataTable
         Dim Villages As New IMIS_BL.LocationsBL
-        Return Villages.GetVillages(WardId, True)
+        Return Villages.GetVillages(WardId, showSelect)
     End Function
     Public Function GetGender() As DataTable
         Dim Gender As New IMIS_BL.GenderBL

--- a/IMIS_BL/LocationsBL.vb
+++ b/IMIS_BL/LocationsBL.vb
@@ -33,27 +33,22 @@ Public Class LocationsBL
     Public Function GetDistricts(ByVal userID As Integer, ByVal showSelect As Boolean, ByVal RegionId As Integer, Optional EnforceSelect As Boolean = False) As DataTable
         Dim Districts As New IMIS_DAL.LocationsDAL
         Dim dt As DataTable = Districts.GetDistricts(userID, RegionId:=RegionId)
-
-        If dt.Rows.Count > 1 Or EnforceSelect Then
-            If showSelect = True Then
-                Dim dr As DataRow = dt.NewRow
-                dr("DistrictId") = 0
-                dr("DistrictName") = imisgen.getMessage("T_SELECTDISTRICT")
-                dt.Rows.InsertAt(dr, 0)
-            End If
+        If showSelect = True Then
+            Dim dr As DataRow = dt.NewRow
+            dr("DistrictId") = 0
+            dr("DistrictName") = imisgen.getMessage("T_SELECTDISTRICT")
+            dt.Rows.InsertAt(dr, 0)
         End If
         Return dt
     End Function
     Public Function GetDistrictsAll(ByVal userID As Integer, Optional RegionId As Integer = 0, Optional ByVal showSelect As Boolean = False, Optional Authority As Integer = 0) As DataTable
         Dim Districts As New IMIS_DAL.LocationsDAL
         Dim dt As DataTable = Districts.GetDistrictsALL(userID, RegionId)
-        If dt.Rows.Count > 1 Then
-            If showSelect = True Then
-                Dim dr As DataRow = dt.NewRow
-                dr("DistrictId") = 0
-                dr("DistrictName") = imisgen.getMessage("T_SELECTDISTRICT")
-                dt.Rows.InsertAt(dr, 0)
-            End If
+        If showSelect = True Then
+            Dim dr As DataRow = dt.NewRow
+            dr("DistrictId") = 0
+            dr("DistrictName") = imisgen.getMessage("T_SELECTDISTRICT")
+            dt.Rows.InsertAt(dr, 0)
         End If
         Return dt
     End Function
@@ -64,29 +59,25 @@ Public Class LocationsBL
     Public Function GetVillages(ByVal WardID As Integer, Optional ByVal showSelect As Boolean = False) As DataTable
         Dim Villages As New IMIS_DAL.LocationsDAL
         Dim dt As DataTable = Villages.GetVillages(WardID)
-        If dt.Rows.Count > 1 Then
-            If showSelect = True Then
-                Dim dr As DataRow = dt.NewRow
-                dr("VillageId") = 0
-                dr("VillageName") = imisgen.getMessage("T_SELECTAVILLAGE")
-                dt.Rows.InsertAt(dr, 0)
-            End If
+
+        If showSelect = True Then
+            Dim dr As DataRow = dt.NewRow
+            dr("VillageId") = 0
+            dr("VillageName") = imisgen.getMessage("T_SELECTAVILLAGE")
+            dt.Rows.InsertAt(dr, 0)
         End If
         Return dt
     End Function
     Public Function GetWards(ByVal DistrictID As Integer, Optional ByVal showSelect As Boolean = False) As DataTable
         Dim Wards As New IMIS_DAL.LocationsDAL
         Dim dt As DataTable = Wards.GetWards(DistrictID)
-        If dt.Rows.Count > 1 Then
-            If showSelect = True Then
-                Dim dr As DataRow = dt.NewRow
-                dr("WardId") = 0
-                dr("WardName") = imisgen.getMessage("T_SELECTAWARD")
-                dt.Rows.InsertAt(dr, 0)
+        If showSelect = True Then
+            Dim dr As DataRow = dt.NewRow
+            dr("WardId") = 0
+            dr("WardName") = imisgen.getMessage("T_SELECTAWARD")
+            dt.Rows.InsertAt(dr, 0)
 
-            End If
         End If
-
         Return dt
     End Function
 
@@ -216,7 +207,7 @@ Public Class LocationsBL
             dr("RegionName") = imisgen.getMessage("M_NATIONAL")
             dt.Rows.InsertAt(dr, 0)
         End If
-        If ShowSelect = True And dt.Rows.Count > 1 Then
+        If ShowSelect = True Then
             Dim dr As DataRow
             dr = dt.NewRow
             dr("RegionId") = 0
@@ -236,7 +227,7 @@ Public Class LocationsBL
             dr("RegionName") = imisgen.getMessage("M_NATIONAL")
             dt.Rows.InsertAt(dr, 0)
         End If
-        If ShowSelect = True And dt.Rows.Count > 1 Then
+        If ShowSelect = True Then
             Dim dr As DataRow
             dr = dt.NewRow
             dr("RegionId") = 0


### PR DESCRIPTION
Changes:
- Made location related calls always respect the `showSelect` flag (deleted hardcoded `showSelect` values and additional condisions regarding number of rows)
- Changed values of `showSelect` flag in Family.aspx and ChangeFamily.apsx to `False`

[https://openimis.atlassian.net/browse/OTC-68](https://openimis.atlassian.net/browse/OTC-68)