### PR TITLE
OTC-70: RFC 103 Report Overview of Commissions

### DIFF
--- a/IMIS/Reports.aspx
+++ b/IMIS/Reports.aspx
@@ -469,7 +469,7 @@ In case of dispute arising out or in relation to the use of the program, it is s
                                     </li>
                                     <li class="pd doi ca oc">
                                         <asp:Label ID="lblMonth" runat="server" Text='<%$ Resources:Resource, L_MONTH %>' CssClass="FormLabel"></asp:Label>
-                                        <asp:DropDownList ID="ddlMonth" Width="90px" runat="server">
+                                        <asp:DropDownList ID="ddlMonth" Width="90px" runat="server" AutoPostBack="true">
                                         </asp:DropDownList>
 
                                     </li>
@@ -499,7 +499,7 @@ In case of dispute arising out or in relation to the use of the program, it is s
                                     </li>
                                     <li class="pd doi poi poiC ca oc">
                                         <asp:Label ID="lblYear" runat="server" Text='<%$ Resources:Resource, L_YEAR %>' CssClass="FormLabel"></asp:Label>
-                                        <asp:DropDownList ID="ddlYear" Width="68px" runat="server">
+                                        <asp:DropDownList ID="ddlYear" Width="68px" runat="server" AutoPostBack="true">
                                         </asp:DropDownList>
                                     </li>
                                     <li class="pd doi  perc ca cp cna ">

--- a/IMIS_BI/ReportsBI.vb
+++ b/IMIS_BI/ReportsBI.vb
@@ -226,9 +226,9 @@ Public Class ReportsBI
         Dim gen As New IMIS_BL.GeneralBL
         Return gen.GetMode()
     End Function
-    Public Function GetPreviousOverviewOfCommissionsReportDates(ByVal UserID As Integer, ByVal DistrictID As Integer, ByVal ReportingID As Integer?, Year As Integer, Month As Integer) As DataTable
+    Public Function GetPreviousOverviewOfCommissionsReportDates(ByVal UserID As Integer, ByVal LocationID As Integer, ByVal ReportingID As Integer?, Year As Integer, Month As Integer) As DataTable
         Dim Rep As New IMIS_BL.ReportingBL
-        Return Rep.GetPreviousOverviewOfCommissionsReportDates(UserID, DistrictID, ReportingID, Year, Month)
+        Return Rep.GetPreviousOverviewOfCommissionsReportDates(UserID, LocationID, ReportingID, Year, Month)
     End Function
 
     Public Function GetOverviewOfCommissions(ByVal LocationId As Integer?, ByVal ProductId As Integer?, ByVal Month As Integer?, ByVal Year As Integer?, ByVal PayerId As Integer?, ByVal OfficerId As Integer?, ByVal Mode As Integer, ByVal CommissionRate As Decimal?, ByVal Scope As Integer, ByVal ReportingID As Integer?, ByRef ErrorMessage As String, ByRef oReturn As Integer) As DataTable

--- a/IMIS_BL/ReportingBL.vb
+++ b/IMIS_BL/ReportingBL.vb
@@ -38,9 +38,16 @@ Public Class ReportingBL
         End If
         Return dt
     End Function
-    Public Function GetPreviousOverviewOfCommissionsReportDates(ByVal UserID As Integer, ByVal DistrictID As Integer, ByVal ReportingID As Integer?, Year As Integer, Month As Integer) As DataTable
+    Public Function GetPreviousOverviewOfCommissionsReportDates(ByVal UserID As Integer, ByVal LocationID As Integer, ByVal ReportingID As Integer?, Year As Integer, Month As Integer) As DataTable
+        Dim dt As DataTable
+        If ReportingID Is Nothing And LocationID = 0 And Year = 0 And Month = 0 Then
+            dt = New DataTable
+            dt.Columns.Add("ReportingId")
+            dt.Columns.Add("Display")
+        Else
+            dt = DALRep.GetPreviousOverviewOfCommissiosReportDates(UserID, LocationID, ReportingID, Year, Month)
+        End If
 
-        Dim dt = DALRep.GetPreviousOvervireOfCommissiosReportDates(UserID, DistrictID, ReportingID, Year, Month)
         If ReportingID Is Nothing Then
             Dim dr As DataRow = dt.NewRow
             dr("ReportingId") = 0

--- a/IMIS_DAL/ReportingDAL.vb
+++ b/IMIS_DAL/ReportingDAL.vb
@@ -50,29 +50,31 @@ Public Class ReportingDAL
         data.params("@LocationId", SqlDbType.Int, LocationId)
         Return data.Filldata()
     End Function
-    Public Function GetPreviousOvervireOfCommissiosReportDates(ByVal UserID As Integer, ByVal LocationId As Integer, ByVal ReportingID As Integer?, Year As Integer, Month As Integer) As DataTable
+    Public Function GetPreviousOverviewOfCommissiosReportDates(ByVal UserID As Integer, ByVal LocationId As Integer, ByVal ReportingID As Integer?, Year As Integer, Month As Integer) As DataTable
         Dim Overview As String = "'" + getMessage("T_OVERVIEW") + " - '"
         Dim AllDetails As String = "'" + getMessage("T_ALLDETAILS") + " - '"
 
-        Query = "SELECT  RP.LocationId,RP.CommissionRate,R.RegionId,RP.OfficerID,RP.PayerId, RP.ProdId,Prod.ProductCode+' ' +Prod.ProductName ProductCode,RP.ReportMode,RP.CommissionRate,RP.ReportingId,RP.StartDate,RP.EndDate,
-CASE RP.Scope WHEN 0 THEN " & Overview & " WHEN 1 THEN " & AllDetails & " END " &
- " + ' ' + CONCAT(FORMAT(RP.StartDate,'MMMM','en-US') , ' ' ,Year(RP.StartDate)) " &
-  " + ' ' + CASE RP.ReportMode  WHEN 0 THEN 'Prescribed Contributions' WHEN 1 THEN 'Actually Paid Contributions' ELSE ''  END" &
-  " + ' ' + CAST(RP.CommissionRate AS nvarchar)+'% ' + ' ' + ISNULL(Prod.ProductCode,'') + ' ' +ISNULL(O.LastName,'')+' '+ ISNULL(O.OtherNames,'')" &
- " + ' ' +R.RegionName+ '  ' + Dis.DistrictName " &
-  "+ '  ' + CAST(RP.ReportingDate AS CHAR(20))" &
-  "+ '  ' + ISNULL(PY.PayerName,'') Display FROM tblReporting RP" &
-  " INNER JOIN tblDistricts Dis ON Dis.DistrictID = RP.LocationId" &
-  " INNER JOIN tblRegions R ON R.RegionId = Dis.Region" &
-  " LEFT JOIN tblProduct Prod ON Prod.ProdID = RP.ProdId" &
-  " LEFT OUTER JOIN tblPayer PY ON PY.PayerID = RP.PayerId" &
-  " INNER JOIN tblUsersDistricts UD ON Dis.DistrictID = UD.LocationId" &
-   " LEFT JOIN tblOfficer O ON O.OfficerID = RP.OfficerID" &
-  " WHERE RP.ReportingId = CASE WHEN @ReportingID IS NULL THEN RP.ReportingID ELSE @ReportingID END" &
-  " AND RP.ReportType =2" &
-   " AND Year(RP.StartDate) = @Year AND Month(RP.StartDate)  =@Month" &
-   " AND UD.ValidityTo IS NULL AND UD.UserID = @UserId" &
-  " AND RP.LocationId = CASE WHEN @LocationId = 0 THEN RP.LocationId ELSE @LocationId END ORDER BY ReportingId DESC"
+        Query = "SELECT  RP.LocationId,RP.CommissionRate,R.RegionId,RP.OfficerID,RP.PayerId, RP.ProdId,Prod.ProductCode+' ' +Prod.ProductName ProductCode,RP.ReportMode,RP.CommissionRate,RP.ReportingId,RP.StartDate,RP.EndDate
+                ,R.RegionId,Dis.DistrictId, YEAR(RP.StartDate) as 'Year', MONTH(RP.StartDate) as 'Month',
+                CASE RP.Scope WHEN 0 THEN " & Overview & " WHEN 1 THEN " & AllDetails & " ELSE ' - ' END " &
+                " + ' ' + CONCAT(FORMAT(RP.StartDate,'MMMM','en-US') , ' ' ,Year(RP.StartDate)) " &
+                " + ' ' + CASE RP.ReportMode  WHEN 0 THEN 'Prescribed Contributions' WHEN 1 THEN 'Actually Paid Contributions' ELSE ''  END" &
+                " + ' ' + CAST(RP.CommissionRate AS nvarchar)+'% ' + ' ' + ISNULL(Prod.ProductCode,'') + ' ' +ISNULL(O.LastName,'')+' '+ ISNULL(O.OtherNames,'')" &
+                " + ' ' +R.RegionName+ '  ' + Dis.DistrictName " &
+                "+ '  ' + CAST(RP.ReportingDate AS CHAR(20))" &
+                "+ '  ' + ISNULL(PY.PayerName,'') Display FROM tblReporting RP" &
+                " INNER JOIN tblDistricts Dis ON Dis.DistrictID = RP.LocationId" &
+                " INNER JOIN tblLocations L on RP.LocationId = L.LocationId" &
+                " INNER JOIN tblRegions R ON R.RegionId = Dis.Region" &
+                " LEFT JOIN tblProduct Prod ON Prod.ProdID = RP.ProdId" &
+                " LEFT OUTER JOIN tblPayer PY ON PY.PayerID = RP.PayerId" &
+                " INNER JOIN tblUsersDistricts UD ON Dis.DistrictID = UD.LocationId" &
+                " LEFT JOIN tblOfficer O ON O.OfficerID = RP.OfficerID" &
+                " WHERE RP.ReportingId = CASE WHEN @ReportingID IS NULL THEN RP.ReportingID ELSE @ReportingID END" &
+                " AND RP.ReportType =2" &
+                " AND (Year(RP.StartDate) = @Year OR @Year = 0) AND (Month(RP.StartDate) = @Month OR @Month = 0)" &
+                " AND UD.ValidityTo IS NULL AND UD.UserID = @UserId" &
+                " AND (@LocationId = 0 OR @LocationId = L.LocationId OR @LocationId = L.ParentLocationId) ORDER BY ReportingId DESC"
         data.setSQLCommand(Query, CommandType.Text)
         data.params("@ReportingID", SqlDbType.Int, ReportingID)
         data.params("@UserID", SqlDbType.Int, UserID)


### PR DESCRIPTION
Changes:
- Added additional events to reload previous reports when year, month, region or district are changed
- Fixed `ddlYear`, using display name as value (which happened to be the same for all but one entry)
- Modified the query to allow retrieving previous reports based on any number of fields
- Fixed setting up mode of selected report

[https://openimis.atlassian.net/browse/OTC-70](https://openimis.atlassian.net/browse/OTC-70)