### PR TITLE
OTC-278: fix displaying payment with validity to not null

### DIFF
--- a/IMIS_DAL/PaymentDAL.vb
+++ b/IMIS_DAL/PaymentDAL.vb
@@ -260,7 +260,6 @@ Public Class PaymentDAL
         End If
 
         ' sSQL += " AND PD.ValidityTo IS NULL	"
-        sSQL += " And PY.ValidityTo Is NULL"
         data.setSQLCommand(sSQL, CommandType.Text)
         data.params("@PaymentDetailsID", SqlDbType.Int, PaymentDetailsID)
         data.params("@dtPaymentStatus", ePayment.dtPaymentStatus, "xPayementStatus")


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OTC-278

Fix issue raised by @dragos-dobre 

Payment Overview : Admin : System.IndexOutOfRangeException: There is no row at position 0.
   at System.Data.RBTree`1.GetNodeByIndex(Int32 userIndex)
   at System.Data.DataRowCollection.get_Item(Int32 index)
   at IMIS.PaymentOverview.LoadDetails() in C:\Users\user\Documents\web_app_vb\IMIS\PaymentOverview.aspx.vb:line 316
   at IMIS.PaymentOverview.loadGrid() in C:\Users\user\Documents\web_app_vb\IMIS\PaymentOverview.aspx.vb:line 99
   at IMIS.PaymentOverview.Page_Load(Object sender, EventArgs e) in C:\Users\user\Documents\web_app_vb\IMIS\PaymentOverview.aspx.vb:line 81

It was because cancelled payment has set 'ValidityTo'. And that getPaymentDetails obtain only Payment with ValidityTo = NULL 