### PR TITLE
OTC-273: display payment id in payment overview instead of uuid

### DIFF
--- a/IMIS/PaymentOverview.aspx
+++ b/IMIS/PaymentOverview.aspx
@@ -148,10 +148,10 @@ In case of dispute arising out or in relation to the use of the program, it is s
                         </td>
                        
                         <td class="FormLabel">
-                            <asp:Label ID="lblMatchedDate0" runat="server" Text="<%$ Resources:Resource,L_INTERNALID %>"></asp:Label>
+                            <asp:Label ID="lblMatchedDate0" runat="server" Text="<%$ Resources:Resource,L_PAYMENTID %>"></asp:Label>
                         </td>
                         <td class="ReadOnlyText">
-                            <asp:Label ID="txtInternalIdentifier" runat="server"></asp:Label>
+                            <asp:Label ID="txtPaymentId" runat="server"></asp:Label>
                         </td>
 
                         <td class="FormLabel">

--- a/IMIS/PaymentOverview.aspx.designer.vb
+++ b/IMIS/PaymentOverview.aspx.designer.vb
@@ -230,13 +230,13 @@ Partial Public Class PaymentOverview
     Protected WithEvents lblMatchedDate0 As Global.System.Web.UI.WebControls.Label
 
     '''<summary>
-    '''txtInternalIdentifier control.
+    '''txtPaymentId control.
     '''</summary>
     '''<remarks>
     '''Auto-generated field.
     '''To modify move field declaration from designer file to code-behind file.
     '''</remarks>
-    Protected WithEvents txtInternalIdentifier As Global.System.Web.UI.WebControls.Label
+    Protected WithEvents txtPaymentId As Global.System.Web.UI.WebControls.Label
 
     '''<summary>
     '''lblExpectedAmount control.

--- a/IMIS/PaymentOverview.aspx.vb
+++ b/IMIS/PaymentOverview.aspx.vb
@@ -129,7 +129,7 @@ Public Class PaymentOverview
         txtPhoneNo.Text = entities.PhoneNumber
         txtMatchedDate.Text = If(entities.MatchedDate Is Nothing, "", entities.MatchedDate)
         txtStatus.Text = If(entities.PaymentStatusName IsNot Nothing, entities.PaymentStatusName, "")
-        txtInternalIdentifier.Text = payment_id
+        txtPaymentId.Text = If(entities.PaymentID <> Nothing, entities.PaymentID, "")
         txtPaymentOrigin.Text = If(entities.PaymentOrigin IsNot Nothing, entities.PaymentOrigin, "")
         txtExpectedAmounts.Text = If(entities.ExpectedAmount IsNot Nothing, entities.ExpectedAmount, "")
         txtReceivedAmount.Text = If(entities.ReceivedAmount IsNot Nothing, entities.ReceivedAmount, "")


### PR DESCRIPTION
part of TICKET: https://openimis.atlassian.net/browse/OTC-273

another change requested by @dragos-dobre  to show paymentId (billId) instead of payment uuid (internal id).

![id3](https://user-images.githubusercontent.com/52816247/121641702-ce95f400-ca8f-11eb-9476-383379adb43d.PNG)
