### PR TITLE
OP-361: cannot add service to price list

### DIFF
--- a/IMIS_DAL/PricelistMSDAL.vb
+++ b/IMIS_DAL/PricelistMSDAL.vb
@@ -136,7 +136,7 @@ Public Class PricelistMSDAL
         data.params("@PLServiceID", SqlDbType.Int, ePLServices.PLServiceID)
         data.params("@PLServName", SqlDbType.NVarChar, 100, ePLServices.PLServName)
         data.params("@DatePL", SqlDbType.SmallDateTime, ePLServices.DatePL)
-        data.params("@LocationId", SqlDbType.Int, if(ePLServices.tblLocations.LocationId = -1, Nothing, ePLServices.tblLocations.LocationId))
+        data.params("@LocationId", SqlDbType.Int, If(ePLServices.tblLocations.LocationId = -1, DBNull.Value, ePLServices.tblLocations.LocationId))
         data.params("@LegacyID", SqlDbType.Int, 1, ParameterDirection.Output)
         data.params("@AuditUserID", SqlDbType.Int, ePLServices.AuditUserID)
         data.ExecuteCommand()


### PR DESCRIPTION
Changes:
- Changed value for national price list from `Nothing` to `DBNull.Value` to fix the SQL exception on updating the price list

[https://openimis.atlassian.net/browse/OP-361](https://openimis.atlassian.net/browse/OP-361)