### PR TITLE
OP-368: NULL value in HFAddress gives exception

### DIFF
--- a/IMIS_DAL/HealthFacilityDAL.vb
+++ b/IMIS_DAL/HealthFacilityDAL.vb
@@ -250,26 +250,26 @@ Public Class HealthFacilityDAL
         data.params("@HFID", SqlDbType.Int, eHF.HfID)
         Dim dr As DataRow = data.Filldata()(0)
         If Not dr Is Nothing Then
-            eHF.HFName = dr("HFName")
-            eHF.LegalForm = dr("LegalForm")
-            eHF.HFLevel = dr("HFLevel")
-            eHF.HFSublevel = dr("HFSublevel").ToString
-            eHF.HFCode = dr("HFCode")
-            eHF.HFAddress = dr("HFAddress")
-            eHF.RegionId = dr("RegionId")
+            eHF.HFName = IIf(dr("HFName") Is DBNull.Value, Nothing, dr("HFName"))
+            eHF.LegalForm = IIf(dr("LegalForm") Is DBNull.Value, Nothing, dr("LegalForm"))
+            eHF.HFLevel = IIf(dr("HFLevel") Is DBNull.Value, Nothing, dr("HFLevel"))
+            eHF.HFSublevel = IIf(dr("HFSublevel") Is DBNull.Value, Nothing, dr("HFSublevel").ToString)
+            eHF.HFCode = IIf(dr("HFCode") Is DBNull.Value, Nothing, dr("HFCode"))
+            eHF.HFAddress = IIf(dr("HFAddress") Is DBNull.Value, Nothing, dr("HFAddress"))
+            eHF.RegionId = IIf(dr("RegionId") Is DBNull.Value, Nothing, dr("RegionId"))
             eLocations.LocationId = dr("DistrictId")
             eHF.tblLocations = eLocations
-            eHF.Phone = dr("Phone")
-            eHF.Fax = dr("Fax")
-            eHF.eMail = dr("eMail")
-            eHF.HFCareType = dr("HFCareType")
+            eHF.Phone = IIf(dr("Phone") Is DBNull.Value, Nothing, dr("Phone"))
+            eHF.Fax = IIf(dr("Fax") Is DBNull.Value, Nothing, dr("Fax"))
+            eHF.eMail = IIf(dr("eMail") Is DBNull.Value, Nothing, dr("eMail"))
+            eHF.HFCareType = IIf(dr("HFCareType") Is DBNull.Value, Nothing, dr("HFCareType"))
             ePLService.PLServiceID = dr("PLServiceID")
             eHF.tblPLServices = ePLService
             ePLItem.PLItemID = dr("PLItemID")
             eHF.AccCode = dr("AccCode")
             eHF.tblPLItems = ePLItem
 
-            eHF.ValidityTo = if(dr("ValidityTo").ToString = String.Empty, Nothing, dr("ValidityTo"))
+            eHF.ValidityTo = IIf(dr("ValidityTo") Is DBNull.Value Or dr("ValidityTo").ToString = String.Empty, Nothing, dr("ValidityTo"))
         End If
 
     End Sub


### PR DESCRIPTION
Changes:
- Added DBNull value checks to LoadHF method for every nullable field

[https://openimis.atlassian.net/browse/OP-368](https://openimis.atlassian.net/browse/OP-368)