### PR TITLE
OS-80: Fixed LFI issue with report generating.

### DIFF
--- a/IMIS/Registers.aspx.vb
+++ b/IMIS/Registers.aspx.vb
@@ -384,7 +384,6 @@ Partial Public Class UploadICD
         Dim strCommand As String = ""
         Dim file As System.IO.FileInfo = New System.IO.FileInfo(path)
         Dim settingsPath As String = System.Configuration.ConfigurationManager.AppSettings("ExportFolder").ToString()
-        Debug.WriteLine(settingsPath)
         ' To prevent LFI exploit check if files comes from reports folder
         ' To prevent cases such as "exports\..\..\secret_file.txt" use getfullpath
         If file.Exists And System.IO.Path.GetFullPath(path).Contains(settingsPath) Then

--- a/IMIS/Registers.aspx.vb
+++ b/IMIS/Registers.aspx.vb
@@ -26,7 +26,6 @@
 ' 
 '
 
-
 Partial Public Class UploadICD
     Inherits System.Web.UI.Page
 
@@ -384,7 +383,11 @@ Partial Public Class UploadICD
     Private Sub DownloadFile(path As String, contentType As String)
         Dim strCommand As String = ""
         Dim file As System.IO.FileInfo = New System.IO.FileInfo(path)
-        If file.Exists Then
+        Dim settingsPath As String = System.Configuration.ConfigurationManager.AppSettings("ExportFolder").ToString()
+        Debug.WriteLine(settingsPath)
+        ' To prevent LFI exploit check if files comes from reports folder
+        ' To prevent cases such as "exports\..\..\secret_file.txt" use getfullpath
+        If file.Exists And System.IO.Path.GetFullPath(path).Contains(settingsPath) Then
             strCommand = "attachment;filename=" & System.IO.Path.GetFileName(path)
             Response.AppendHeader("Content-Disposition", strCommand)
             Response.ContentType = contentType


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OS-80

Changes:
* Functions gets path for reports from settings file
* Functions sanitizes input by getting full path (no "example\..\..")
* Compares requested filepath with that in settings - if they are not the same no file is given to user.

