### PR TITLE
OTC-492: Fixed handling of region and district in claim overview.

### DIFF
--- a/IMIS/Reports.aspx.vb
+++ b/IMIS/Reports.aspx.vb
@@ -1506,7 +1506,7 @@ Partial Public Class Reports
         Try
 
             CacheCriteria()
-
+            ' SelectedValueID tells which element of the list is chosen 
             Dim SelectedValueID As Integer = lstboxReportSelector.SelectedValue
             If SelectedValueID = 1 Then
                 If Val(ddlProduct.SelectedValue) = 0 Then
@@ -1527,8 +1527,8 @@ Partial Public Class Reports
                     Return
                 End If
             End If
-
-            If SelectedValueID = 2 Or SelectedValueID = 22 Then
+            ' SelectedValueID = 13 is ClaimOverview
+            If SelectedValueID = 2 Or SelectedValueID = 22 Or SelectedValueID = 13 Then
                 If Val(ddlRegionWoNational.SelectedValue) = 0 Then
                     lblMsg.Text = imisgen.getMessage("M_PLEASESELECTAREGION")
                     Return

--- a/IMIS/Reports.aspx.vb
+++ b/IMIS/Reports.aspx.vb
@@ -1010,14 +1010,21 @@ Partial Public Class Reports
         Return True
     End Function
     Private Function GetClaimOverview() As Boolean
-        Dim DistrictID As Integer?
+        Dim LocationId As Integer?
         Dim ProdID As Integer?
         Dim HfID As Integer?
         Dim StartDate As Date?
         Dim EndDate As Date?
         Dim ClaimStatus As Integer?
         Dim Scope As Integer?
-        DistrictID = If(Val(ddlDistrictWoNational.SelectedValue) > 0, CInt(Val(ddlDistrictWoNational.SelectedValue)), Nothing)
+        If Val(ddlDistrictWoNational.SelectedValue) > 0 Then
+            LocationId = CInt(ddlDistrictWoNational.SelectedValue)
+        ElseIf Val(ddlRegionWoNational.SelectedValue) > 0 Then
+            LocationId = ddlRegionWoNational.SelectedValue
+
+        Else
+            LocationId = Nothing
+        End If
         ProdID = If(Val(ddlAllProducts.SelectedValue) > 0, CInt(ddlAllProducts.SelectedValue), Nothing)
         HfID = If(Val(ddlHF.SelectedValue) > 0, CInt(ddlHF.SelectedValue), Nothing)
         StartDate = If(IsDate(txtSTARTData.Text.Trim), Date.ParseExact(txtSTARTData.Text.Trim, "dd/MM/yyyy", Nothing), Nothing)
@@ -1028,8 +1035,8 @@ Partial Public Class Reports
         If ddlScope.SelectedIndex > 0 Then
             Scope = ddlScope.SelectedValue
         End If
-        dt = reports.GetClaimOverview(DistrictID, ProdID, HfID, StartDate, EndDate, ClaimStatus, Scope, oReturn)
-        Session("Scope") = Scope
+            dt = reports.GetClaimOverview(LocationId, ProdID, HfID, StartDate, EndDate, ClaimStatus, Scope, oReturn)
+            Session("Scope") = Scope
         If dt IsNot Nothing AndAlso dt.Rows.Count > 0 Then
             IMIS_EN.eReports.SubTitle = imisgen.getMessage("L_HFACILITY") & " : " & dt.Rows(0)("HFCode") & " - " & dt.Rows(0)("HFName") & If(ddlAllProducts.SelectedValue > 0, " | " & imisgen.getMessage("L_PRODUCT") & " : " & ddlAllProducts.SelectedItem.Text, "") & " | " & LocationName & " | " & imisgen.getMessage("L_PERIOD") & "  " & imisgen.getMessage("L_FROM") & " " & StartDate & " " & imisgen.getMessage("L_TO") & " " & EndDate
             IMIS_EN.eReports.SubTitle += vbNewLine & " | " & imisgen.getMessage("L_SCOPE") & " : " & ddlScope.SelectedItem.Text

--- a/IMIS_BI/ReportsBI.vb
+++ b/IMIS_BI/ReportsBI.vb
@@ -139,9 +139,9 @@ Public Class ReportsBI
         Dim BL As New IMIS_BL.ReportBL
         Return BL.GetMatchingFunds(DistrictID, ProdID, PayerID, StartDate, EndDate, ReportingID, ErrorMessage, oReturn)
     End Function
-    Public Function GetClaimOverview(ByVal DistrictID As Integer?, ByVal ProdID As Integer?, ByVal HfID As Integer?, ByVal StartDate As Date?, ByVal EndDate As Date?, ByVal ClaimStatus As Integer?, ByVal Scope As Integer?, ByRef oReturn As Integer) As DataTable
+    Public Function GetClaimOverview(ByVal LocationId As Integer?, ByVal ProdID As Integer?, ByVal HfID As Integer?, ByVal StartDate As Date?, ByVal EndDate As Date?, ByVal ClaimStatus As Integer?, ByVal Scope As Integer?, ByRef oReturn As Integer) As DataTable
         Dim BL As New IMIS_BL.ReportBL
-        Return BL.GetClaimOverview(DistrictID, ProdID, HfID, StartDate, EndDate, ClaimStatus, Scope, oReturn)
+        Return BL.GetClaimOverview(LocationId, ProdID, HfID, StartDate, EndDate, ClaimStatus, Scope, oReturn)
     End Function
     Public Function GetPercentageReferral(RegionId As Integer, DistrictId As Integer, StartDate As Date, EndDate As Date) As DataTable
         Dim Report As New IMIS_BL.ReportBL

--- a/IMIS_BL/ReportBL.vb
+++ b/IMIS_BL/ReportBL.vb
@@ -176,12 +176,12 @@ Public Class ReportBL
         Dim DAL As New IMIS_DAL.ReportDAL
         Return DAL.GetMatchingFunds(DistrictID, ProdID, PayerID, StartDate, EndDate, ReportingID, ErrorMessage, oReturn)
     End Function
-    Public Function GetClaimOverview(ByVal DistrictID As Integer?, ByVal ProdID As Integer?, ByVal HfID As Integer?, ByVal StartDate As Date?, ByVal EndDate As Date?, ByVal ClaimStatus As Integer?, ByVal Scope As Integer?, ByRef oReturn As Integer) As DataTable
+    Public Function GetClaimOverview(ByVal LocationId As Integer?, ByVal ProdID As Integer?, ByVal HfID As Integer?, ByVal StartDate As Date?, ByVal EndDate As Date?, ByVal ClaimStatus As Integer?, ByVal Scope As Integer?, ByRef oReturn As Integer) As DataTable
         Dim DAL As New IMIS_DAL.ReportDAL
         Dim imisgen As New GeneralBL
         Dim dtRejReason = New DataTable
         dtRejReason = imisgen.GetAllRejectedReasons()
-        Return DAL.GetClaimOverview(DistrictID, ProdID, HfID, StartDate, EndDate, ClaimStatus, Scope, dtRejReason, oReturn)
+        Return DAL.GetClaimOverview(LocationId, ProdID, HfID, StartDate, EndDate, ClaimStatus, Scope, dtRejReason, oReturn)
     End Function
     Public Function GetPercentageReferral(RegionId As Integer, DistrictId As Integer, StartDate As Date, EndDate As Date) As DataTable
         Dim Report As New IMIS_DAL.ReportDAL


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OTC-492

Changes:
- Claim overview now allows to check claims from the whole region, not only from the district as it was the case
- Changed variable name to be more appropriate (DistrictID -> LocationID)
- Claim overview now forces user to choose a region

This feature requires changes to the database:
https://github.com/openimis/database_ms_sqlserver/pull/124
