### PR TITLE
OP-171:  in service list, Service filters (Name and codes) don't find partial hits

### DIFF
--- a/IMIS_BL/MedicalItemsBL.vb
+++ b/IMIS_BL/MedicalItemsBL.vb
@@ -30,10 +30,11 @@ Public Class MedicalItemsBL
     Private imisgen As New GeneralBL
     Public Function GetMedicalItems(ByVal eItems As IMIS_EN.tblItems, Optional ByVal All As Boolean = False) As DataTable
         Dim getDataTable As New IMIS_DAL.MedicalItemsDAL
-        eItems.ItemCode += "%"
-        eItems.ItemName += "%"
-        eItems.ItemType += "%"
-        eItems.ItemPackage += "%"
+        eItems.ItemCode = "%" & eItems.ItemCode & "%"
+        eItems.ItemName = "%" & eItems.ItemName & "%"
+        eItems.ItemType = "%" & eItems.ItemType & "%"
+        eItems.ItemPackage = "%" & eItems.ItemPackage & "%"
+
         Dim dtIType As DataTable = GetItemType()
         Return getDataTable.GetMI(eItems, All, dtIType)
 

--- a/IMIS_BL/MedicalServicesBL.vb
+++ b/IMIS_BL/MedicalServicesBL.vb
@@ -52,9 +52,10 @@ Public Class MedicalServicesBL
         If Not dtSType.Columns.Contains("AltLanguage") Then dtSType.Columns.Add("AltLanguage")
         If Not dtServLevel.Columns.Contains("AltLanguage") Then dtServLevel.Columns.Add("AltLanguage")
 
-        eService.ServCode += "%"
-        eService.ServName += "%"
-        eService.ServType += "%"
+        eService.ServCode = "%" & eService.ServCode & "%"
+        eService.ServName = "%" & eService.ServName & "%"
+        eService.ServType = "%" & eService.ServType & "%"
+
         If All = True Then
             Return getDataTable.GetMSLegacy(eService, dtSType, dtServLevel)
         Else


### PR DESCRIPTION
Wild card added before and after the string in Items and Services search form

https://openimis.atlassian.net/browse/OP-171