### PR TITLE
OTC-523: correction of displaying report 'ClaimOverview with detail'

### DIFF
--- a/IMIS/Reports/rptClaimOverviewAllDetails.rdlc
+++ b/IMIS/Reports/rptClaimOverviewAllDetails.rdlc
@@ -1503,8 +1503,8 @@
                                               <Paragraph>
                                                 <TextRuns>
                                                   <TextRun>
-                                                    <Value>=Parameters!paramItemQty.Value</Value>
-                                                    <Style>
+                                                    <Value>=Fields!OrgQtyItem.Value</Value>
+													  <Style>
                                                       <FontSize>6pt</FontSize>
                                                     </Style>
                                                   </TextRun>
@@ -1533,7 +1533,7 @@
                                               <Paragraph>
                                                 <TextRuns>
                                                   <TextRun>
-                                                    <Value>=Sum(Fields!OrgQtyItem.Value)</Value>
+                                                    <Value>=Fields!ItemQtyApproved.Value</Value>
                                                     <Style>
                                                       <FontSize>6pt</FontSize>
                                                     </Style>
@@ -2107,7 +2107,7 @@
                                               <Paragraph>
                                                 <TextRuns>
                                                   <TextRun>
-                                                    <Value>=Parameters!paramServiceQty.Value</Value>
+                                                    <Value>=Fields!OrgQtyService.Value</Value>
                                                     <Style>
                                                       <FontSize>6pt</FontSize>
                                                     </Style>
@@ -2137,7 +2137,7 @@
                                               <Paragraph>
                                                 <TextRuns>
                                                   <TextRun>
-                                                    <Value>=Sum(Fields!ServiceQtyApproved.Value)</Value>
+                                                    <Value>=Fields!ServiceQtyApproved.Value</Value>
                                                     <Style>
                                                       <FontSize>6pt</FontSize>
                                                       <FontWeight>Bold</FontWeight>


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OTC-523

What is fixed:
- fixing displaying 'quantity' data in 'ClaimOverviewWithDetail' report.

Presentation of change based on demo data on localhost:
![otc-523_a](https://user-images.githubusercontent.com/52816247/171871702-2f3fa50c-497b-4ff3-a407-810d17f54eb2.PNG)
![otc-523_c](https://user-images.githubusercontent.com/52816247/171871724-87344c77-98dc-4259-8c97-f6bc27e66477.PNG)
![otc-523_b](https://user-images.githubusercontent.com/52816247/171871720-62b4a4ac-7bc2-43a1-b4f7-5f819c1c2ab3.PNG)

