### PR TITLE
OP-735: fixed 'restoring claim' functionality

### DIFF
--- a/IMIS/Claim.aspx.vb
+++ b/IMIS/Claim.aspx.vb
@@ -537,7 +537,6 @@ Partial Public Class Claim
         Return "Continue"
     End Function
     Private Sub B_SAVE_Click(ByVal sender As Object, ByVal e As System.EventArgs) Handles B_SAVE.Click
-        Dim eClaimBeforeRestore As New IMIS_EN.tblClaim
         Dim chkSaveClaimItems, chkSaveClaim, chkSaveClaimServices As Integer
         Dim oldClaimId As Integer
         eClaim.ClaimID = hfClaimID.Value
@@ -553,7 +552,6 @@ Partial Public Class Claim
                     'Starts
                     If CInt(Session("RestoreMode")) = True Then
                         'In all cases for restoring claims the initial claim must be unchanged'
-                        'eClaimBeforeRestore = eClaim'
                         oldClaimId = eClaim.ClaimID
                         eClaim.ClaimID = 0
                         If Not eClaim.ClaimStatus = 1 Then


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OP-735

Changes: 
a) creating new claim in restored claim - no more updating existing claim (Initial claim is not changed)
a) for all Valid Claim : checked, processed and validated)
- remove insuree ID (CHF id)
- remove claim code
b) for rejected Claim
- add @ prefix to claim code