### PR TITLE
OP-786 Added claim related tables to claims export

### DIFF
--- a/IMIS_BL/IMISExtractsBL.vb
+++ b/IMIS_BL/IMISExtractsBL.vb
@@ -424,14 +424,24 @@ Public Class IMISExtractsBL
         con.ConnectionString = "Data source = " & DB_NAME
         con.Open()
         'con.ChangePassword(DB_PWD)
-        cmd = con.CreateCommand
 
         Dim sSQL As String = ""
         Dim strPhoto As String = ""
-        sSQL = "CREATE TABLE tblPolicyInquiry(CHFID text,Photo BLOB, InsureeName Text, DOB Text, Gender Text, ProductCode Text, ProductName Text, ExpiryDate Text, Status Text, DedType Int, Ded1 Int, Ded2 Int, Ceiling1 Int, Ceiling2 Int)"
-        cmd.CommandText = sSQL
-        cmd.ExecuteNonQuery()
 
+        Dim createTablesSql As String =
+            "CREATE TABLE tblPolicyInquiry(InsureeNumber text,Photo BLOB, InsureeName Text, DOB Text, Gender Text, ProductCode Text, ProductName Text, ExpiryDate Text, Status Text, DedType Int, Ded1 Int, Ded2 Int, Ceiling1 Int, Ceiling2 Int);" +
+            "CREATE TABLE tblReferences([Code] Text, [Name] Text, [Type] Text, [Price] INT);" +
+            "CREATE TABLE tblControls([FieldName] Text, [Adjustability] Text, [Usage] Text);" +
+            "CREATE TABLE tblClaimAdmins([Code] Text, [Name] Text)" +
+            "CREATE TABLE tblClaimDetails(ClaimUUID TEXT, ClaimDate TEXT, HFCode TEXT, ClaimAdmin TEXT, ClaimCode TEXT, InsureeNumber TEXT, StartDate TEXT, EndDate TEXT, ICDCode TEXT, Comment TEXT, Total TEXT, ICDCode1 TEXT, ICDCode2 TEXT, ICDCode3 TEXT, ICDCode4 TEXT, VisitType TEXT);" +
+            "CREATE TABLE tblClaimItems(ClaimUUID TEXT, ItemCode TEXT, ItemPrice TEXT, ItemQuantity TEXT);" +
+            "CREATE TABLE tblClaimServices(ClaimUUID TEXT, ServiceCode TEXT, ServicePrice TEXT, ServiceQuantity TEXT);" +
+            "CREATE TABLE tblClaimUploadStatus(ClaimUUID TEXT, UploadDate TEXT, UploadStatus TEXT, UploadMessage TEXT);"
+
+        cmd = con.CreateCommand
+        cmd.CommandText = createTablesSql
+        cmd.ExecuteNonQuery()
+        cmd.Dispose()
 
         If WithInsuree = True Then
             '  dtExtractSource = ExtractDAL.GetPhoneExtractSource(eExtractInfo.DistrictID)
@@ -441,7 +451,7 @@ Public Class IMISExtractsBL
             Using InsertCmd = New SQLiteCommand(con)
                 Using transaction = con.BeginTransaction
                     For Each row In dtExtractSource.Rows
-                        sSQL = "INSERT INTO tblPolicyInquiry(CHFID ,Photo , InsureeName, DOB, Gender, ProductCode, ProductName, ExpiryDate, Status, DedType, Ded1, Ded2, Ceiling1, Ceiling2)" &
+                        sSQL = "INSERT INTO tblPolicyInquiry(InsureeNumber ,Photo , InsureeName, DOB, Gender, ProductCode, ProductName, ExpiryDate, Status, DedType, Ded1, Ded2, Ceiling1, Ceiling2)" &
                        " VALUES(@CHFID,@image,@InsureeName,@DOB,@Gender,@ProductCode,@ProductName,@ExpiryDate,@Status,@DedType,@Ded1,@Ded2,@Ceiling1,@Ceiling2)"
                         InsertCmd.CommandText = sSQL
 
@@ -469,18 +479,9 @@ Public Class IMISExtractsBL
             End Using
 
         End If
-        cmd.Dispose()
-
-        cmd = New SQLite.SQLiteCommand
-        cmd = con.CreateCommand
-        sSQL = "CREATE TABLE tblReferences([Code] Text, [Name] Text, [Type] Text, [Price] INT)"
-        cmd.CommandText = sSQL
-        cmd.ExecuteNonQuery()
 
         Dim dtReference As New DataTable
         dtReference = ExtractDAL.getReferences()
-
-
 
         Using InsertCmd = New SQLiteCommand(con)
             Using transaction = con.BeginTransaction
@@ -502,14 +503,6 @@ Public Class IMISExtractsBL
             End Using
         End Using
 
-        cmd.Dispose()
-
-        cmd = New SQLite.SQLiteCommand
-        cmd = con.CreateCommand
-        sSQL = "CREATE TABLE tblControls([FieldName] Text, [Adjustibility] Text, [Usage] Text)"
-        cmd.CommandText = sSQL
-        cmd.ExecuteNonQuery()
-
         Dim dtControls As New DataTable
         Dim ControlsDAL As New IMIS_DAL.ControlsDAL
         dtControls = ControlsDAL.getControlsSettings()
@@ -517,13 +510,13 @@ Public Class IMISExtractsBL
         Using InsertCmd = New SQLiteCommand(con)
             Using transaction = con.BeginTransaction
                 For Each row In dtControls.Rows
-                    sSQL = "INSERT INTO tblControls([FieldName],[Adjustibility],[Usage])" &
-                           " VALUES(@FieldName,@Adjustibility,@Usage)"
+                    sSQL = "INSERT INTO tblControls([FieldName],[Adjustability],[Usage])" &
+                           " VALUES(@FieldName,@Adjustability,@Usage)"
 
                     InsertCmd.CommandText = sSQL
 
                     InsertCmd.Parameters.AddWithValue("@FieldName", row("FieldName").ToString)
-                    InsertCmd.Parameters.AddWithValue("@Adjustibility", row("Adjustibility").ToString)
+                    InsertCmd.Parameters.AddWithValue("@Adjustability", row("Adjustibility").ToString)
                     InsertCmd.Parameters.AddWithValue("@Usage", row("Usage").ToString)
 
                     InsertCmd.ExecuteNonQuery()
@@ -533,14 +526,7 @@ Public Class IMISExtractsBL
             End Using
         End Using
 
-        cmd.Dispose()
-
         Dim locationId = eExtractInfo.LocationId
-        cmd = con.CreateCommand
-        sSQL = "CREATE TABLE tblClaimAdmins([Code] Text, [Name] Text)"
-        cmd.CommandText = sSQL
-        cmd.ExecuteNonQuery()
-
         Dim dtClaimAdmins As New DataTable
         Dim ExtractsDAL As New IMIS_DAL.IMISExtractsDAL
         dtClaimAdmins = ExtractsDAL.GetPhoneExtractsClaimAdmins(locationId)
@@ -557,13 +543,10 @@ Public Class IMISExtractsBL
                     InsertCmd.Parameters.AddWithValue("@Name", (row("LastName") + " " + row("OtherNames")).ToString)
 
                     InsertCmd.ExecuteNonQuery()
-
                 Next
                 transaction.Commit()
             End Using
         End Using
-
-        cmd.Dispose()
 
         con.Close()
 

--- a/IMIS_DAL/IMISExtractsDAL.vb
+++ b/IMIS_DAL/IMISExtractsDAL.vb
@@ -548,7 +548,7 @@ Public Class IMISExtractsDAL
     End Function
     Public Sub SubmitClaimFromXML(ByVal Xml As XmlDocument)
         Dim data As New ExactSQL
-        Dim sSQL As String = "uspUpdateClaimFromPhone"
+        Dim sSQL As String = "uspRestApiUpdateClaimFromPhone"
 
         data.setSQLCommand(sSQL, CommandType.StoredProcedure)
         data.params("@XML", Xml.InnerXml)


### PR DESCRIPTION
Changes:
- Added `Claim` related tables to sqlite export for Claims app
- Changed `uspUpdateClaimFromPhone` to `uspRestApiUpdateClaimFromPhone` in import claims XML feature, as the first one is to be used with the WebServices version of the app