### PR TITLE
OTC-661: EO Substitution looks like mandatory 

### DIFF
--- a/IMIS/Officer.aspx
+++ b/IMIS/Officer.aspx
@@ -508,24 +508,22 @@ In case of dispute arising out or in relation to the use of the program, it is s
                                 </td>
                             </tr>
                             <tr>
-                                <td class="auto-style32">
+                                <td class="FormLabel">
                                     <asp:Label ID="L_SUBSTITUTION" runat="server" Text='<%$ Resources:Resource,L_SUBSTITUTION %>'></asp:Label>
                                 </td>
                                 <td class="DataEntry">
                                     <asp:UpdatePanel ID="UpdatePanel1" runat="server">
                                         <ContentTemplate>
-                                            <asp:DropDownList ID="ddlSubstitution" runat="server">
+                                            <asp:DropDownList ID="ddlSubstitution" runat="server" AutoPostBack="true">
                                             </asp:DropDownList>
                                             <asp:Label ID="Label2" runat="server" Text="*" ForeColor="Red" Visible="false" Display="Dynamic"></asp:Label>
-                                            <asp:RequiredFieldValidator ID="RequiredFieldValidator2" runat="server" ControlToValidate="ddlSubstitution" InitialValue="0" ValidationGroup="check" ForeColor="Red" Display="Dynamic"
-                                            Text='*'></asp:RequiredFieldValidator>
+                                            <asp:CustomValidator ControlToValidate="ddlSubstitution" ValidationGroup="check" ForeColor="Red" Display="Dynamic" InitialValue="0" runat="server" OnServerValidate="SubstitutionValidator" Text='*'></asp:CustomValidator>
                                         </ContentTemplate>
                                     </asp:UpdatePanel>
                                 </td>
-                                <td class="auto-style36"></td>
                             </tr>
                             <tr>
-                                <td class="FormLabel" valign="top">
+                                <td class="FormLabel">
                                     <asp:Label ID="L_WorksTo" runat="server" Text='<%$ Resources:Resource,L_WORKSTO %>'></asp:Label>
                                 </td>
                                 <td class="DataEntry" colspan="1">
@@ -536,14 +534,8 @@ In case of dispute arising out or in relation to the use of the program, it is s
                                         UserDateFormat="DayMonthYear">
                                     </asp:MaskedEditExtender>
                                     <asp:Button ID="Button2" runat="server" Class="dateButton" />
-
-
                                     <asp:CalendarExtender ID="CalendarExtender2" runat="server" TargetControlID="txtWorksTo" PopupButtonID="Button2" Format="dd/MM/yyyy"></asp:CalendarExtender>
-                                    <asp:RegularExpressionValidator ID="RegularExpressionValidatortxtWorksTo" runat="server"
-                                        ControlToValidate="txtWorksTo" SetFocusOnError="True"
-                                        ValidationExpression="^(0[1-9]|[12][0-9]|3[01])[/](0[1-9]|1[012])[/](19|20)\d\d$"
-                                        ValidationGroup="check" ForeColor="Red" Display="Dynamic"
-                                        Text='*'></asp:RegularExpressionValidator>
+                                    <asp:CustomValidator ControlToValidate="txtWorksTo" ValidationGroup="check" ForeColor="Red" Display="Dynamic" InitialValue="0" runat="server" OnServerValidate="WorksToValidator" Text='*'></asp:CustomValidator>
                                 </td>
                                 <td>
                                 </td>

--- a/IMIS/Officer.aspx.designer.vb
+++ b/IMIS/Officer.aspx.designer.vb
@@ -392,15 +392,6 @@ Partial Public Class Officer
     Protected WithEvents Label2 As Global.System.Web.UI.WebControls.Label
 
     '''<summary>
-    '''RequiredFieldValidator2 control.
-    '''</summary>
-    '''<remarks>
-    '''Auto-generated field.
-    '''To modify move field declaration from designer file to code-behind file.
-    '''</remarks>
-    Protected WithEvents RequiredFieldValidator2 As Global.System.Web.UI.WebControls.RequiredFieldValidator
-
-    '''<summary>
     '''L_WorksTo control.
     '''</summary>
     '''<remarks>
@@ -444,15 +435,6 @@ Partial Public Class Officer
     '''To modify move field declaration from designer file to code-behind file.
     '''</remarks>
     Protected WithEvents CalendarExtender2 As Global.AjaxControlToolkit.CalendarExtender
-
-    '''<summary>
-    '''RegularExpressionValidatortxtWorksTo control.
-    '''</summary>
-    '''<remarks>
-    '''Auto-generated field.
-    '''To modify move field declaration from designer file to code-behind file.
-    '''</remarks>
-    Protected WithEvents RegularExpressionValidatortxtWorksTo As Global.System.Web.UI.WebControls.RegularExpressionValidator
 
     '''<summary>
     '''chkCheckAllWards control.

--- a/IMIS/Officer.aspx.vb
+++ b/IMIS/Officer.aspx.vb
@@ -64,6 +64,7 @@ Partial Public Class Officer
                 FillDistrict()
             End If
             FillLanguage()
+            changeEnabledValidatorFieldsInIncludeLogin(False)
 
             If Not eOfficer.OfficerID = 0 Then
                 Officer.LoadOfficer(eOfficer)
@@ -97,6 +98,7 @@ Partial Public Class Officer
                     ddlLanguage.SelectedValue = eUsers.LanguageID
                     RequiredFieldConfirmPassword.Visible = False
                     RequiredFieldPassword.Visible = False
+                    changeEnabledValidatorFieldsInIncludeLogin(True)
                 End If
             Else
 
@@ -120,13 +122,32 @@ Partial Public Class Officer
 #End Region
 #Region "Buttons"
     Protected Sub B_SAVE_Click(ByVal sender As Object, ByVal e As EventArgs) Handles B_SAVE.Click
-        Dim Valid As Boolean = SaveOfficer()
-
-        If Not Valid Then
-            Exit Sub
+        If Page.IsValid Then
+            Dim Valid As Boolean = SaveOfficer()
+            If Valid Then
+                Response.Redirect("FindOfficer.aspx?o=" & txtCode.Text.Trim)
+            End If
         End If
+    End Sub
 
-        Response.Redirect("FindOfficer.aspx?o=" & txtCode.Text.Trim)
+    Protected Sub SubstitutionValidator(ByVal Sender As Object, ByVal args As ServerValidateEventArgs)
+        If Not (String.IsNullOrEmpty(ddlSubstitution.SelectedValue) Or ddlSubstitution.SelectedValue = "0") And Not IsDate(txtWorksTo.Text) Then
+            lblmsg.Text = imisgen.getMessage("M_WORKSTO")
+            args.IsValid = False
+        Else
+            args.IsValid = True
+        End If
+    End Sub
+
+    Protected Sub WorksToValidator(ByVal Sender As Object, ByVal args As ServerValidateEventArgs)
+        If Not String.IsNullOrEmpty(txtWorksTo.Text) And Not IsDate(txtWorksTo.Text) Then
+            args.IsValid = False
+        ElseIf IsDate(txtWorksTo.Text) And (String.IsNullOrEmpty(ddlSubstitution.SelectedValue) Or ddlSubstitution.SelectedValue = "0") Then
+            lblmsg.Text = imisgen.getMessage("M_SUBSTITUTE")
+            args.IsValid = False
+        Else
+            args.IsValid = True
+        End If
     End Sub
 
     Protected Sub chkOfficerIncludeLogin_CheckedChanged(ByVal sender As Object, ByVal e As EventArgs)
@@ -150,17 +171,6 @@ Partial Public Class Officer
         Try
             Dim dt As New DataTable
             dt = DirectCast(Session("User"), DataTable)
-
-            If IsDate(txtWorksTo.Text) And String.IsNullOrEmpty(ddlSubstitution.SelectedValue) Then
-                Session("msg") = imisgen.getMessage("M_SUBSTITUTE")
-                Return False
-            End If
-
-
-            If Not String.IsNullOrEmpty(ddlSubstitution.SelectedValue) And Not IsDate(txtWorksTo.Text) Then
-                Session("msg") = imisgen.getMessage("M_WORKSTO")
-                Return False
-            End If
 
             Dim eLocations As New IMIS_EN.tblLocations
 


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OTC-661](https://openimis.atlassian.net/browse/OTC-661)

Changes:
- Replaced default validators for "Substitution" and "Works to" fields with custom validators
- Fixed check for empty "Substitution" field
- Added missing events for enabling and disabling "Include Login" fields
- Added missing validation check in "Save" button event
